### PR TITLE
30685 usagi properties file

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -57,6 +57,46 @@ class ScanReportValue(BaseModel):
     value = models.CharField(max_length=32)
     frequency = models.IntegerField()
 
+# class UsagiProperties(BaseModel):
+#     """
+#     Model to hold information on the Usagi input settings
+#     """
+#     scan_report_field = models.ForeignKey(ScanReportField, on_delete=models.CASCADE)
+#     usagiFolder = models.Charfield(max_length=64)
+#     vocabFolder = models.Charfield(max_length=64)
+#     sourceFile = models.Charfield(max_length=64)
+#     mappingFile = models.Charfield(max_length=64)
+#     source_code_col = models.Charfield(max_length=64)
+#     source_name_col = models.Charfield(max_length=64)
+#     positive_answer = models.Charfield(max_length=64)
+#     negative_answer = models.Charfield(max_length=64)
+#     source_field_code = models.Charfield(max_length=64)
+#     source_field_desc = models.Charfield(max_length=64)
+#     threshold = models.DecimalField(decimal_places=2, max_digits=10)
+#     additional_info_cols = models.Charfield(max_length=64)
+#
+#     def __str__(self):
+#         return f'{self.scan_report_field}'
+#
+# class UsagiOutput(BaseModel):
+#     """
+#     Model to hold information on the results of a Usagi run
+#     """
+#     usagi_properties_file = models.ForeignKey(UsagiProperties, on_delete=models.CASCADE)
+#     source_code = models.Charfield(max_length=64)
+#     source_name = models.Charfield(max_length=64)
+#     source_freq = models.IntegerField()
+#     match_score = models.DecimalField(decimal_places=2, max_digits=10)
+#     mapping_status = models.Charfield(max_length=64)
+#     target_concept_id = models.IntegerField()
+#     target_concept_name = models.Charfield(max_length=64)
+#     target_vocab_id = models.Charfield(max_length=64)
+#     target_domain_id = models.Charfield(max_length=64)
+#     target_standard_concept = models.Charfield(max_length=5)
+#     target_concept_class = models.Charfield(max_length=64)
+#     target_concept_code = models.IntegerField()
+#     target_invalid_reason = models.Charfield(max_length=64)
+
 
 class Source(BaseModel):
     """

--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -159,4 +159,5 @@ def process_scan_report(scan_report_id):
 
 def run_usagi():
     print('Running Usagi...')
-    subprocess.Popen('java -jar Usagi.jar', shell=True, cwd="/api/mapping/data/usagi")
+    p1 = subprocess.Popen('java -jar Usagi.jar run ~/Documents/phenobase/usagi.properties', cwd="/api/mapping/data/usagi", shell=True, stdout=subprocess.PIPE)
+    p1.stdout.read()

--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -1,5 +1,5 @@
 import csv
-
+import subprocess
 from xlsx2csv import Xlsx2csv
 
 from .models import ScanReport, ScanReportTable, ScanReportField, \
@@ -155,3 +155,8 @@ def process_scan_report(scan_report_id):
                 value=result[1],
                 frequency=frequency,
             )
+
+
+def run_usagi():
+    print('Running Usagi...')
+    subprocess.Popen('java -jar Usagi.jar', shell=True, cwd="/api/mapping/data/usagi")

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -1,18 +1,19 @@
 from django.test import TestCase
 
-from .services import process_scan_report_sheet_table
-
+from .services import process_scan_report_sheet_table, run_usagi
 
 class ServiceTests(TestCase):
 
-    def test_process_scan_report_sheet_table(self):
+    # def test_process_scan_report_sheet_table(self):
+    #     # Tell it what file you want to process
+    #     filename = '/api/mapping/data/value_frequency_test_data.csv'
+    #
+    #     # Run the test on filename
+    #     # This function is in services.py
+    #     result = process_scan_report_sheet_table(filename)
+    #
+    #     self.assertIs(4, len(result))
 
-            # Tell it what file you want to process
-            filename = '/api/mapping/data/value_frequency_test_data.csv'
-
-            # Run the test on filename
-            # This function is in services.py
-            result = process_scan_report_sheet_table(filename)
-
-
-        self.assertIs(4, len(result))
+    def test_run_usagi(self):
+        x = run_usagi()
+        print(x)

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
         htop \
         wait-for-it \
         binutils \
-        gettext
+        gettext \
+        default-jre
 
 RUN addgroup -q django && \
     adduser --quiet --ingroup django --disabled-password django
@@ -29,4 +30,3 @@ USER django
 ENV PATH=/home/django/.local/bin:$PATH
 
 RUN pip install -r /requirements.txt
-


### PR DESCRIPTION
I've created a simple test method for Usagi CLI. In this update I have:

- Created a Usagi folder containing a stand-alone version of the compiled Usagi.jar file (which outputs all fields)
- Added default-jre to dockerfile to install Java for Usagi.jar

Build and run the app, then `docker-compose exec api python manage.py test`, you will get an error that Uasgi can't find the properties file. This is expected behaviour - the error means that Usagi runs. I haven't written the code yet to perform a full run of Usagi because we need to have a discussion about where to store indexes during development (I'm not sure what the best thing to do is, because the index is large). Once we've discussed this, I can work out a way of running a full Usagi run (hard-coded) before moving onto representing the properties file in a model (to be called dynamically).

