### PR TITLE
29519 structural mapping form

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -42,8 +42,6 @@ class Mapping(BaseModel):
     def __str__(self):
         return f'{self.table, self.field}'
 
-
-
 class ClassificationSystem(BaseModel):
     """
     Class for 'classification system', i.e. SNOMED or ICD-10 etc.
@@ -73,6 +71,7 @@ class ScanReport(BaseModel):
         blank=True,
         null=True
     )
+
 
     def __str__(self):
         return f'{self.data_partner, self.dataset,self.author}'
@@ -107,7 +106,6 @@ class ScanReportField(BaseModel):
         blank=True
     )
     mapping = models.ManyToManyField(Mapping)
-
     def __str__(self):
         return self.name
 

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -2,11 +2,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
 
-"""
-Relationship is many:many because;
-Each pair of source data tables/fields can potentially be related to many tables/fields in OMOP
-Each pair of tables/fields in OMOP can be related to many different pairs of tables/fields in the source data
-"""
+
 
 
 class BaseModel(models.Model):
@@ -15,6 +11,37 @@ class BaseModel(models.Model):
 
     class Meta:
         abstract = True
+
+"""
+Relationship is many:many because;
+Each pair of source data tables/fields can potentially be related to many tables/fields in OMOP
+Each pair of tables/fields in OMOP can be related to many different pairs of tables/fields in the source data
+"""
+
+
+class Source(BaseModel):
+    """
+    DEFINE MODEL TO HOLD INFORMATION ON THE SOURCE DATA TABLES AND COLUMNS
+    """
+    dataset = models.CharField(max_length=64)
+    table = models.CharField(max_length=64)
+    field = models.CharField(max_length=64)
+    mapping = models.ManyToManyField('Mapping')
+
+    def __str__(self):
+        return f'{self.dataset, self.table, self.field}'
+
+
+class Mapping(BaseModel):
+    """
+    DEFINE MODEL TO HOLD THE POSSIBLE OMOP MAPPING COMBINATIONS
+    """
+    table = models.CharField(max_length=64)
+    field = models.CharField(max_length=64)
+
+    def __str__(self):
+        return f'{self.table, self.field}'
+
 
 
 class ClassificationSystem(BaseModel):
@@ -79,6 +106,7 @@ class ScanReportField(BaseModel):
         null=True,
         blank=True
     )
+    mapping = models.ManyToManyField(Mapping)
 
     def __str__(self):
         return self.name
@@ -92,27 +120,4 @@ class ScanReportValue(BaseModel):
     def __str__(self):
         return self.value
 
-
-class Source(BaseModel):
-    """
-    DEFINE MODEL TO HOLD INFORMATION ON THE SOURCE DATA TABLES AND COLUMNS
-    """
-    dataset = models.CharField(max_length=64)
-    table = models.CharField(max_length=64)
-    field = models.CharField(max_length=64)
-    mapping = models.ManyToManyField('Mapping')
-
-    def __str__(self):
-        return f'{self.dataset, self.table, self.field}'
-
-
-class Mapping(BaseModel):
-    """
-    DEFINE MODEL TO HOLD THE POSSIBLE OMOP MAPPING COMBINATIONS
-    """
-    table = models.CharField(max_length=64)
-    field = models.CharField(max_length=64)
-
-    def __str__(self):
-        return f'{self.table, self.field}'
 

--- a/api/mapping/templates/mapping/mapping_form.html
+++ b/api/mapping/templates/mapping/mapping_form.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h2>Edit Structural Mapping Field</h2>
+
+{% endblock %}

--- a/api/mapping/templates/mapping/mapping_form.html
+++ b/api/mapping/templates/mapping/mapping_form.html
@@ -3,5 +3,8 @@
 {% block body %}
 
 <h2>Edit Structural Mapping Field</h2>
-
+<form method="post">{% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Update">
+</form>
 {% endblock %}

--- a/api/mapping/templates/mapping/scanreportfield_list.html
+++ b/api/mapping/templates/mapping/scanreportfield_list.html
@@ -32,7 +32,8 @@
                 <th scope="col">Is Date Event</th>
                 <th scope="col">Ignore?</th>
                 <th scope="col">Classification System</th>
-                <th></th>
+                <th>Edit</th>
+                <th>Structural Mapping</th>
             </tr>
             </thead>
             <tbody>
@@ -48,9 +49,11 @@
                 <td>{{ object.is_date_event }}</td>
                 <td>{{ object.is_ignore }}</td>
                 <td>{{ object.classification_system.name }}</td>
-                <td><a href="{% url 'scan-report-field-update' object.id %}">Edit
-                    Field</a></td>
-                <td></td>
+                <td><a href="{% url 'scan-report-field-update' object.id %}">Edit Field</a></td>
+                <td>{% for object in object.mapping.all %}
+                    <b>{{object.table}}</b>
+                    {{object.field|linebreaks}}
+                    {% endfor %}</td>
             </tr>
             {% endfor %}
             </tbody>

--- a/api/mapping/templates/mapping/scanreportfield_list.html
+++ b/api/mapping/templates/mapping/scanreportfield_list.html
@@ -34,6 +34,7 @@
                 <th scope="col">Classification System</th>
                 <th>Edit</th>
                 <th>Structural Mapping</th>
+                <th>Edit Structural Mappings</th>
             </tr>
             </thead>
             <tbody>
@@ -51,9 +52,11 @@
                 <td>{{ object.classification_system.name }}</td>
                 <td><a href="{% url 'scan-report-field-update' object.id %}">Edit Field</a></td>
                 <td>{% for object in object.mapping.all %}
+
                     <b>{{object.table}}</b>
                     {{object.field|linebreaks}}
                     {% endfor %}</td>
+                <td><a href="{% url 'scan-report-mapping-update' object.id %}">Edit Structural Mapping</a></td>
             </tr>
             {% endfor %}
             </tbody>

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('tables/', views.ScanReportTableListView.as_view(), name='tables'),
     path('fields/', views.ScanReportFieldListView.as_view(), name='fields'),
     path('fields/<int:pk>/update/', views.ScanReportFieldUpdateView.as_view(), name='scan-report-field-update'),
+    path('fields/<int:pk>/update_mapping/', views.ScanReportStructuralMappingUpdateView.as_view(), name='scan-report-mapping-update'),
     path('scanreports/', login_required(views.ScanReportListView.as_view()), name='scan-report-list'),
     path('scanreports/create/', login_required(views.ScanReportFormView.as_view()), name='scan-report-form'),
     path('signup/', views.SignUpView.as_view(), name='signup'),

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -106,10 +106,14 @@ class ScanReportFieldUpdateView(UpdateView):
         'is_date_event',
         'is_ignore',
         'classification_system',
+        'mapping'
     ]
 
     def get_success_url(self):
         return "{}?search={}".format(reverse('fields'), self.object.scan_report_table.id)
+
+class ScanReportStructuralMappingUpdateView(UpdateView):
+    model = ScanReportField
 
 
 class ScanReportListView(ListView):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -13,8 +13,7 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from django.views import generic
 from django.views.generic import ListView
-from django.views.generic.edit import FormView
-from django.views.generic.edit import UpdateView
+from django.views.generic.edit import FormView, UpdateView
 
 from .forms import ScanReportForm, UserCreateForm
 from .models import Mapping, Source, ScanReport, ScanReportField, \
@@ -111,12 +110,13 @@ class ScanReportFieldUpdateView(UpdateView):
         return "{}?search={}".format(reverse('fields'), self.object.scan_report_table.id)
 
 class ScanReportStructuralMappingUpdateView(UpdateView):
-    model = Mapping
-    template = "/mapping/mapping_form.html"
+    model = ScanReportField
     fields = [
-        'table',
-        'field',
+        'mapping'
     ]
+
+    def get_success_url(self):
+        return "{}?search={}".format(reverse('fields'), self.object.scan_report_table.id)
 
 class ScanReportListView(ListView):
     model = ScanReport

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -19,7 +19,6 @@ from django.views.generic.edit import UpdateView
 from .forms import ScanReportForm, UserCreateForm
 from .models import Mapping, Source, ScanReport, ScanReportField, \
     ScanReportTable
-# We probably need to deprecate this function
 from .tasks import process_scan_report_task
 
 
@@ -106,15 +105,18 @@ class ScanReportFieldUpdateView(UpdateView):
         'is_date_event',
         'is_ignore',
         'classification_system',
-        'mapping'
     ]
 
     def get_success_url(self):
         return "{}?search={}".format(reverse('fields'), self.object.scan_report_table.id)
 
 class ScanReportStructuralMappingUpdateView(UpdateView):
-    model = ScanReportField
-
+    model = Mapping
+    template = "/mapping/mapping_form.html"
+    fields = [
+        'table',
+        'field',
+    ]
 
 class ScanReportListView(ListView):
     model = ScanReport

--- a/docker/django/requirements.txt
+++ b/docker/django/requirements.txt
@@ -4,3 +4,4 @@ celery
 pandas
 openpyxl
 xlsx2csv
+django-select2


### PR DESCRIPTION
Attempting to move the structural mapping edit form into it's own place (when you click the link 'Edit Structural Mapping'). 

I've got stuck at the final hurdle - as always it's with URL routing! I really can't work out how urls.py works with the templates and views we create. I think perhaps the code needs to be more verbose when using view classes? Can we consider using arguments in CBVs if they're available (rather than letting Django work behind the scenes)? 

For example:
```
class MyListView(ListView):
    model = MyModel
    template = "app/my_template.html"
```

Rather than:
```
class MyListView(ListView)
    model = MyModel
    ...
    <<Django magic happens here - how does the view route to our template?>>
    ...
```

Sometimes too much abstraction is a bad thing for understanding how the code works!