### PR TITLE
revert navbar colors

### DIFF
--- a/api/static/style/custom.css
+++ b/api/static/style/custom.css
@@ -42,10 +42,14 @@ body {
     padding-right: 40px;
 }
 
-/* make some snazy 90s-like theme for the nav bar */
 .bg-co-connect {
-    background:  linear-gradient(180deg,rgba(0,0,0,0) 0 66px, var(--co-connect-tertiary) 66px 100%),
+    /*
+      make some snazy 90s-like theme for the nav bar 
+    
+      background:  linear-gradient(180deg,rgba(0,0,0,0) 0 66px, var(--co-connect-tertiary) 66px 100%),
 		 linear-gradient(110deg,white 0 40px, var(--co-connect-primary-light) 80px , var(--co-connect-primary) 200px 80%,var(--co-connect-secondary));
+   */
+    background: var(--co-connect-tertiary);
 }
 
 /* change the navbar link colors  and mouse-over actions */


### PR DESCRIPTION
@py5gol this reverts the navbar color to be grey -- a grey consistent with the HDRIGateway palette 

Styles can be easily changed in the file `api/static/style/custom.css`

![image](https://user-images.githubusercontent.com/69473770/107210829-96f13f80-69fc-11eb-80bf-2605ff700b6c.png)
