### PR TITLE
31040 data dictionary parsing

### DIFF
--- a/api/mapping/admin.py
+++ b/api/mapping/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from .models import DocumentType, Source,DataPartners, ScanReport, \
     ScanReportTable, \
     ScanReportField, ScanReportValue,\
-    ClassificationSystem, OmopTable, OmopField, MappingRule,Document,DocumentFile
+    ClassificationSystem, OmopTable, OmopField, MappingRule, Document, DocumentFile, DataDictionary
 
 admin.site.register(DataPartners)
 admin.site.register(DocumentType)
@@ -18,3 +18,4 @@ admin.site.register(OmopField)
 admin.site.register(MappingRule)
 admin.site.register(Document)
 admin.site.register(DocumentFile)
+admin.site.register(DataDictionary)

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -4,13 +4,13 @@ from django.conf import settings
 import os
 
 
-
 class BaseModel(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         abstract = True
+
 
 """
 Relationship is many:many because;
@@ -48,7 +48,7 @@ class ClassificationSystem(BaseModel):
     Class for 'classification system', i.e. SNOMED or ICD-10 etc.
     """
 
-    name = models.CharField(max_length=64)#128?
+    name = models.CharField(max_length=64)  # 128?
 
     def __str__(self):
         return self.name
@@ -69,11 +69,11 @@ class DocumentType(BaseModel):
 
 
 class ScanReport(BaseModel):
-    name = models.CharField(max_length=256) # Don't think we need this field
+    name = models.CharField(max_length=256)  # Don't think we need this field
     data_partner = models.CharField(max_length=128)
     dataset = models.CharField(max_length=128)
     file = models.FileField()
-    author=models.ForeignKey(
+    author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         blank=True,
@@ -81,7 +81,7 @@ class ScanReport(BaseModel):
     )
 
     def __str__(self):
-        return f'{self.data_partner, self.dataset,self.author}'
+        return f'{self.data_partner, self.dataset, self.author}'
 
 
 class ScanReportTable(BaseModel):
@@ -116,12 +116,14 @@ class ScanReportField(BaseModel):
     def __str__(self):
         return self.name
 
+
 # Models for rule mapping
 class OmopTable(BaseModel):
     table = models.CharField(max_length=64)
 
     def __str__(self):
         return self.table
+
 
 class OmopField(BaseModel):
     table = models.ForeignKey(OmopTable, on_delete=models.CASCADE)
@@ -138,52 +140,55 @@ class MappingRule(BaseModel):
     def __str__(self):
         return f'{self.omop_field, self.scan_report_field}'
 
+
 class ScanReportValue(BaseModel):
     scan_report_field = models.ForeignKey(ScanReportField, on_delete=models.CASCADE)
     value = models.CharField(max_length=32)
     frequency = models.IntegerField()
     conceptID = models.IntegerField(default=-1)
-    
+
     def __str__(self):
         return self.value
 
+
 class Document(BaseModel):
     data_partner = models.ForeignKey(
-            DataPartners, 
-            on_delete=models.CASCADE,
-            blank=True,
-            null=True)
-    owner=models.ForeignKey(
-            settings.AUTH_USER_MODEL,
-            on_delete=models.CASCADE,
-            blank=True,
-            null=True
-        )
-    document_type=models.ForeignKey(
-            DocumentType, 
-            on_delete=models.CASCADE,
-            blank=True,
-            null=True   
+        DataPartners,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True)
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True
     )
-    description=models.CharField(max_length=256)
+    document_type = models.ForeignKey(
+        DocumentType,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True
+    )
+    description = models.CharField(max_length=256)
 
     def __str__(self):
-       
-        return f'{self.data_partner, self.owner,self.document_type,self.description}'
-        
+        return f'{self.data_partner, self.owner, self.document_type, self.description}'
+
+
 class DocumentFile(BaseModel):
-    document_file=models.FileField()
-    size=models.IntegerField()
-    document=models.ForeignKey(
-            Document,
-            on_delete=models.CASCADE,
-            blank=True,
-            null=True)
-    
+    document_file = models.FileField()
+    size = models.IntegerField()
+    document = models.ForeignKey(
+        Document,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True)
+
     def __str__(self):
         self.document_file.name = os.path.basename(self.document_file.name)
 
-        return f'{self.document_file,self.size,self.created_at,self.document_file.name}'
+        return f'{self.document_file, self.size, self.created_at, self.document_file.name}'
+
 
 class DataDictionary(BaseModel):
     table = models.CharField(max_length=128)

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -240,9 +240,9 @@ class DocumentFile(BaseModel):
 class DataDictionary(BaseModel):
     table = models.CharField(max_length=128)
     field = models.CharField(max_length=128)
-    field_description = models.CharField(max_length=256)
+    field_description = models.TextField()
     value_code = models.CharField(max_length=128)
-    value_description = models.CharField(max_length=256)
+    value_description = models.TextField()
 
     def __str__(self):
         return f'{self.table, self.field, self.value_code}'

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -184,3 +184,13 @@ class DocumentFile(BaseModel):
         self.document_file.name = os.path.basename(self.document_file.name)
 
         return f'{self.document_file,self.size,self.created_at,self.document_file.name}'
+
+class DataDictionary(BaseModel):
+    table = models.CharField(max_length=128)
+    field = models.CharField(max_length=128)
+    field_description = models.CharField(max_length=128)
+    value_code = models.CharField(max_length=128)
+    value_description = models.CharField(max_length=128)
+
+    def __str__(self):
+        return f'{self.table, self.field, self.value_code}'

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -188,9 +188,9 @@ class DocumentFile(BaseModel):
 class DataDictionary(BaseModel):
     table = models.CharField(max_length=128)
     field = models.CharField(max_length=128)
-    field_description = models.CharField(max_length=128)
+    field_description = models.CharField(max_length=256)
     value_code = models.CharField(max_length=128)
-    value_description = models.CharField(max_length=128)
+    value_description = models.CharField(max_length=256)
 
     def __str__(self):
         return f'{self.table, self.field, self.value_code}'

--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -184,6 +184,10 @@ def import_data_dictionary(filepath):
 
         # Assumes that the input columns are in the same order as the Twins data dictionary
         for row in reader:
+
+            if row[0][0] == '':
+                continue
+
             print(row)
             
             DataDictionary.objects.create(

--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -181,12 +181,21 @@ def import_data_dictionary():
         # Assumes that the input columns are in the same order as the Twins data dictionary
         for row in reader:
             print(row)
+            
+            # DataDictionary.objects.create(
+            #     table=row[0],
+            #     field=row[1],
+            #     field_description=row[2],
+            #     value_code=row[3],
+            #     value_description=row[4]
+            # )
+
             DataDictionary.objects.create(
-                table=row[0],
-                field=row[1],
-                field_description=row[2],
-                value_code=row[3],
-                value_description=row[4]
+                table="aa",
+                field="bb",
+                field_description="cc",
+                value_code="dd",
+                value_description="ee"
             )
 
     dict_entries = DataDictionary.objects.get(pk=1)

--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -172,13 +172,15 @@ def process_scan_report(scan_report_id):
 
 
 def import_data_dictionary():
-    filepath = "/data/twins_data_dictionary.csv"
+    filepath = "/data/mini_twins_data_dictionary.csv"
 
     with open(filepath, 'rt') as f:
         reader = csv.reader(f)
         next(reader)  # Skip header row
 
+        # Assumes that the input columns are in the same order as the Twins data dictionary
         for row in reader:
+            print(row)
             DataDictionary.objects.create(
                 table=row[0],
                 field=row[1],
@@ -186,4 +188,9 @@ def import_data_dictionary():
                 value_code=row[3],
                 value_description=row[4]
             )
+
+    dict_entries = DataDictionary.objects.get(pk=1)
+    print('>>>>> ', dict_entries)
+
+
 

--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -171,7 +171,7 @@ def process_scan_report(scan_report_id):
             )
 
 
-def process_data_dictionary():
+def import_data_dictionary():
     filepath = "/data/twins_data_dictionary.csv"
 
     with open(filepath, 'rt') as f:
@@ -186,3 +186,4 @@ def process_data_dictionary():
                 value_code=row[3],
                 value_description=row[4]
             )
+

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from .services import process_scan_report_sheet_table
+from .services import process_scan_report_sheet_table, process_data_dictionary
 
 
 class ServiceTests(TestCase):
@@ -15,4 +15,8 @@ class ServiceTests(TestCase):
             result = process_scan_report_sheet_table(filename)
 
 
-        self.assertIs(4, len(result))
+            self.assertIs(4, len(result))
+
+    def test_process_data_dictionary(self):
+        x = process_data_dictionary()
+        print(x)

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from .services import process_scan_report_sheet_table, process_data_dictionary
+from .services import process_scan_report_sheet_table, import_data_dictionary
 
 
 class ServiceTests(TestCase):
@@ -17,6 +17,6 @@ class ServiceTests(TestCase):
 
             self.assertIs(4, len(result))
 
-    def test_process_data_dictionary(self):
-        x = process_data_dictionary()
+    def test_import_data_dictionary(self):
+        x = import_data_dictionary()
         print(x)

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -21,7 +21,7 @@ from .forms import ScanReportForm, UserCreateForm, AddMappingRuleForm, \
     DocumentForm
 from .models import ScanReport, ScanReportValue, ScanReportField, \
     ScanReportTable, MappingRule, OmopTable, OmopField, DocumentFile, Document
-from .tasks import process_scan_report_task, import_data_dictionary
+from .tasks import process_scan_report_task, import_data_dictionary_task
 
 
 @login_required
@@ -302,7 +302,7 @@ class ScanReportFormView(FormView):
         return super().form_valid(form)
 
 
-class DocumentFormView(FormView):  # When is it best to use FormView?
+class DocumentFormView(FormView):
     form_class = DocumentForm
     template_name = 'mapping/upload_document.html'
     success_url = reverse_lazy('document-list')
@@ -325,9 +325,8 @@ class DocumentFormView(FormView):  # When is it best to use FormView?
 
         document_file.save()
 
-        print('>>>> ', document_file.document_file.path)
         filepath = document_file.document_file.path
-        import_data_dictionary(filepath)
+        import_data_dictionary_task.delay(filepath)
 
         return super().form_valid(form)
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -325,8 +325,9 @@ class DocumentFormView(FormView):
 
         document_file.save()
 
-        filepath = document_file.document_file.path
-        import_data_dictionary_task.delay(filepath)
+        # This code will be required later to import a data dictionary into the DataDictionary model
+        # filepath = document_file.document_file.path
+        # import_data_dictionary_task.delay(filepath)
 
         return super().form_valid(form)
 


### PR DESCRIPTION
This PR includes the code to import a data dictionary into the DataDictionary model. I am including this code as a PR so that we can keep it in master until required. We can develop this further as we refine our plan to upload and process data dictionaries. 

At the moment, this code **is not** called in `views.py` (i.e. if someone uploads a data dictionary using Vasiliki's document upload functionality, the data dictionary will not be processed and added to the DataDictionary model). 

If anyone would like to test how the data dictionary data is imported, you can run it via `test_services.py`:
`docker-compose exec api python manage.py test mapping.test_services.ServiceTests.test_import_data_dictionary`

You will need to upload your own data dictionary (in CSV format) to an appropriate location (e.g. data/) in order to run the test (passing the filepath to the file as the filepath argument in the data dictionary function)