### PR TITLE
Fix concept_id re-order bug

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -135,7 +135,7 @@ class ScanReportValueListView(ModelFormSetView):
     factory_kwargs = {'can_delete': False, 'extra': False}
 
     def get_queryset(self):
-         qs = super().get_queryset()
+         qs = super().get_queryset().order_by('id')
          search_term = self.request.GET.get('search', None)
          if search_term is not None:
              qs = qs.filter(scan_report_field=search_term)


### PR DESCRIPTION
This PR:
Adds an order_by clause in the views.py method for scan report values so we avoid the re-ordering of the values after saving the concept_ids