### PR TITLE
If structural mapping already exists do not create again

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -4,9 +4,12 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.constraints import UniqueConstraint
 
+
+STATUS_LIVE='LIVE'
+STATUS_ARCHIVED='ARCHIVED'
 STATUS_CHOICES = [
-    ("LIVE", 'Live'),
-    ("ARCHIVED", 'Archived'),
+    (STATUS_LIVE, 'Live'),
+    (STATUS_ARCHIVED, 'Archived'),
 ]
 
 OPERATION_NONE = 'NONE'
@@ -257,7 +260,7 @@ class DocumentFile(BaseModel):
             on_delete=models.CASCADE,
             blank=True,
             null=True)
-    status=models.CharField(max_length=20,choices=STATUS_CHOICES,default="Archived")
+    status=models.CharField(max_length=20,choices=STATUS_CHOICES,default=STATUS_ARCHIVED)
 
     def __str__(self):
         self.document_file.name = os.path.basename(self.document_file.name)

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -205,14 +205,7 @@ class AddMappingRuleFormView(FormView):
             operation=form.cleaned_data['operation'],
             scan_report_field=scan_report_field,
         )
-        
-        print(created)
         mapping.save()
-        if MappingRule.objects.filter(omop_field=mapping.omop_field,operation=mapping.operation,scan_report_field=mapping.scan_report_field).exists():
-            messages.error(self.request,"mapping already exists")
-        
-            
-
         return super().form_valid(form)
 
     def get_success_url(self):


### PR DESCRIPTION
This PR 
- uses the get_or_create method to check if a structural mapping already exists and if it does doesn't create it again.
- small change in models.py, where we define the STATUS_CHOICES so we have uniformity with OPERATION_CHOICES
- Default value for document model was changed to the STATUS_ARCHIVED so we have the correct default value
