### PR TITLE
31781 pass source value

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -162,6 +162,7 @@ class ScanReportField(BaseModel):
     is_patient_id = models.BooleanField(default=False)
     is_date_event = models.BooleanField(default=False)
     is_ignore = models.BooleanField(default=False)
+    pass_from_source = models.BooleanField(default=False)
     classification_system = models.ForeignKey(
         ClassificationSystem,
         on_delete=models.CASCADE,

--- a/api/mapping/templates/mapping/scanreportfield_list.html
+++ b/api/mapping/templates/mapping/scanreportfield_list.html
@@ -27,6 +27,7 @@
                 <th scope="col">Is Patient ID</th>
                 <th scope="col">Is Date Event</th>
                 <th scope="col">Ignore?</th>
+                <th scope="col">Pass Source Value</th>
                 <th scope="col">Classification System</th>
                 <th>Edit</th>
                 <th colspan="2">Structural Mapping</th>
@@ -52,6 +53,11 @@
                 </td>
                 <td>
                     {% if object.is_ignore %}
+                    <i class="bi bi-check">Yes</i>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if object.pass_from_source %}
                     <i class="bi bi-check">Yes</i>
                     {% endif %}
                 </td>

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -107,6 +107,7 @@ class ScanReportFieldUpdateView(UpdateView):
         'is_patient_id',
         'is_date_event',
         'is_ignore',
+        'pass_from_source',
         'classification_system',
     ]
 


### PR DESCRIPTION
A new column was added to scan report field list that allows users to indicate whether they might want to pass the source value of the desired field as is into the mapping (e.g. age in years, height, weight, etc.)