### PR TITLE
the field names in the scan report field list will be truncated to 20…

### DIFF
--- a/api/mapping/templates/mapping/scanreportfield_list.html
+++ b/api/mapping/templates/mapping/scanreportfield_list.html
@@ -37,7 +37,7 @@
             {% for object in object_list %}
             <tr>
                 <td><a href="{% url 'values' %}?search={{ object.id }}">
-                    {{ object.name }}</a></td>
+                    {{ object.name| truncatechars:20 }}</a></td>
                 <td>
                     {{ object.type_column }}
                 </td>


### PR DESCRIPTION
The field names in the scan report field list are truncated to improve UI.