### PR TITLE
Add conceptID in the ScanReportField model

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -170,6 +170,8 @@ class ScanReportField(BaseModel):
         null=True,
         blank=True
     )
+    concept_id = models.IntegerField(default=-1) 
+
   
     def __str__(self):
         return self.name

--- a/api/mapping/templates/mapping/scanreportfield_list.html
+++ b/api/mapping/templates/mapping/scanreportfield_list.html
@@ -17,7 +17,10 @@
 <h2>Fields</h2>
 
 {% if object_list %}
-<form id="my_form">
+
+<form id="my_form" method="post">
+    {% csrf_token %} 
+     {{ formset.management_form }}
     <div class="form-group">
         <table class="table">
             <thead>
@@ -29,6 +32,7 @@
                 <th scope="col">Ignore?</th>
                 <th scope="col">Pass Source Value</th>
                 <th scope="col">Classification System</th>
+                <th scope="col">Concept ID</th>
                 <th>Edit</th>
                 <th colspan="2">Structural Mapping</th>
             </tr>
@@ -62,6 +66,18 @@
                     {% endif %}
                 </td>
                 <td>{{ object.classification_system.name }}</td>
+
+                <td> {## set i to be the index of the value we're on ##} 
+                        {% with i=forloop.counter %}
+                         {## loop over the formset (editable fields) ##}
+                            {% for form in formset  %}
+                            {% if forloop.counter == i%}
+                                {% for field in form %}
+                                    {{field}}
+                                {% endfor %} 
+                            {% endif %}
+                            {% endfor %}
+                        {% endwith %}</td>
                 <td><a href="{% url 'scan-report-field-update' object.id %}">Edit Field</a></td>
                 <td>
                     <a href="{% url 'view-structural-mapping' object.id %}">View</a>
@@ -73,6 +89,7 @@
             {% endfor %}
             </tbody>
         </table>
+        <button type="submit" class="btn btn-primary">Save</button>
         <!--<div class="form-row">
             <input type="submit" class="btn btn-primary" name="update"
                    value="Update">

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -88,11 +88,13 @@ class ScanReportTableListView(ListView):
 
 
 @method_decorator(login_required,name='dispatch')
-class ScanReportFieldListView(ListView):
+class ScanReportFieldListView(ModelFormSetView):
     model = ScanReportField
+    fields = ["concept_id"]
+    factory_kwargs = {"can_delete": False, "extra": False}
 
     def get_queryset(self):
-        qs = super().get_queryset()
+        qs = super().get_queryset().order_by('id')
         search_term = self.request.GET.get("search", None)
         if search_term is not None:
             qs = qs.filter(scan_report_table__id=search_term)
@@ -120,7 +122,7 @@ class ScanReportFieldListView(ListView):
         )
 
         return context
-
+   
 
 @method_decorator(login_required,name='dispatch')
 class ScanReportFieldUpdateView(UpdateView):
@@ -131,6 +133,7 @@ class ScanReportFieldUpdateView(UpdateView):
         'is_ignore',
         'pass_from_source',
         'classification_system',
+    
     ]
 
     def get_success_url(self):


### PR DESCRIPTION
This PR:

- Adds concept_id as a field in ScanReportField model and sets the default value to be -1
- Allows the user to enter a concept_id for each column if needed and save the entry to the model