### PR TITLE
Fix/remove unmapped fields

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -583,7 +583,7 @@ class StructuralMappingTableListView(ModelFormSetView):
                         if len(qs)>0:
                             _source_field = qs[0]
                             _source_table = _source_field.scan_report_table
-                            #create a new model 
+                        #update model 
                         mapping,created = StructuralMappingRule.objects.update_or_create(
                             scan_report  = scan_report,
                             omop_field   = omop_field,
@@ -603,7 +603,7 @@ class StructuralMappingTableListView(ModelFormSetView):
                         if len(qs)>0:
                             _source_field = qs[0]
                             _source_table = _source_field.scan_report_table
-                            #create a new model 
+                        #update model 
                         mapping,created = StructuralMappingRule.objects.update_or_create(
                             scan_report  = scan_report,
                             omop_field   = omop_field,
@@ -614,11 +614,6 @@ class StructuralMappingTableListView(ModelFormSetView):
                         )
                         mapping.save()
                         
-                    
-                
-                    
-                
-                
                 for destination_field,term_mapping in rules.items():
 
                     try:

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -583,6 +583,16 @@ class StructuralMappingTableListView(ModelFormSetView):
                         if len(qs)>0:
                             _source_field = qs[0]
                             _source_table = _source_field.scan_report_table
+                            #create a new model 
+                        mapping,created = StructuralMappingRule.objects.update_or_create(
+                            scan_report  = scan_report,
+                            omop_field   = omop_field,
+                            source_table = _source_table,
+                            source_field = _source_field,
+                            term_mapping = None,
+                            approved = True,
+                        )
+                        mapping.save()
                     # else try for date fields
                     elif 'date' in omop_field.field:
                         #look for is_date_events in the same table
@@ -593,18 +603,19 @@ class StructuralMappingTableListView(ModelFormSetView):
                         if len(qs)>0:
                             _source_field = qs[0]
                             _source_table = _source_field.scan_report_table
+                            #create a new model 
+                        mapping,created = StructuralMappingRule.objects.update_or_create(
+                            scan_report  = scan_report,
+                            omop_field   = omop_field,
+                            source_table = _source_table,
+                            source_field = _source_field,
+                            term_mapping = None,
+                            approved = True,
+                        )
+                        mapping.save()
                         
                     
-                    #create a new model 
-                    mapping,created = StructuralMappingRule.objects.update_or_create(
-                        scan_report  = scan_report,
-                        omop_field   = omop_field,
-                        source_table = _source_table,
-                        source_field = _source_field,
-                        term_mapping = None,
-                        approved = True,
-                    )
-                    mapping.save()
+                
                     
                 
                 


### PR DESCRIPTION
PR for removing unmapped fields from the structural mapping page. Since we removed the ability to edit them they no longer need to appear on the page.