### PR TITLE
Fix django version on 3.1.8

### DIFF
--- a/docker/django/requirements.txt
+++ b/docker/django/requirements.txt
@@ -1,4 +1,4 @@
-django
+django==3.1.8
 redis
 celery
 pandas


### PR DESCRIPTION
The requirements.txt file does not lock package versions. This PR adds a specific version for Django: 3.1.8.