### PR TITLE
test_services.py code to run NLP

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -140,3 +140,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 CELERY_TIMEZONE = 'UTC'
 CELERY_BROKER_URL = 'redis://redis'
+
+# NLP API KEY
+NLP_API_KEY=os.getenv('NLP_API_KEY')

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -1,26 +1,33 @@
 from django.test import TestCase
-
 from .services import process_scan_report_sheet_table, build_usagi_index, run_usagi
+import time, requests, os, json
+
+from .models import ScanReport, DataPartner, ScanReportTable, ScanReportField, ScanReportValue, DataDictionary
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.contrib.auth.models import User
+from django.conf import settings
+from django.core import serializers
+from django.db.models.functions import Concat
+from django.db.models import CharField, Value as V
+
+
 
 
 class ServiceTests(TestCase):
-
     def test_process_scan_report_sheet_table(self):
 
-            # Tell it what file you want to process
-            filename = '/api/mapping/data/value_frequency_test_data.csv'
+        # Tell it what file you want to process
+        filename = "/api/mapping/data/value_frequency_test_data.csv"
 
-            # Run the test on filename
-            # This function is in services.py
-            result = process_scan_report_sheet_table(filename)
+        # Run the test on filename
+        # This function is in services.py
+        result = process_scan_report_sheet_table(filename)
 
-
-            self.assertIs(4, len(result))
+        self.assertIs(4, len(result))
 
     def test_import_data_dictionary(self):
         x = import_data_dictionary()
         print(x)
-
 
     # Run this to build Usagi's index for the first time
     # Takes a long time to run!
@@ -32,26 +39,139 @@ class ServiceTests(TestCase):
     def test_run_usagi(self):
         x = run_usagi()
         print(x)
-        
+
     def test_nlp(self):
-    
-        # POST 
-        url = "https://ccnett2.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/health/jobs?stringIndexType=TextElements_v8"
-        payload="{\n  \"documents\": [\n    {\n      \"language\": \"en\",\n      \"id\": \"source_field\",\n      \"text\": \"Headache\"\n    }\n  ]\n}"            
-        headers = {
-            'Ocp-Apim-Subscription-Key': os.environ.get('NLP_API_KEY'),
-            'Content-Type': 'application/json; utf-8'
-        }
-
-        response = requests.post(url, headers=headers, data=payload)
-        print('POST STATUS CODE >>> ', response.status_code)
-        print('HEADERS >>> ', response.headers)
         
-        # Add a short artificial wait to give the NLP service
-        # time to run the job
-        time.sleep(5)
+        user = User.objects.get_or_create(
+            username="testuser")[0]
+         
+        data_partner=DataPartner.objects.create(
+            name="UoN"
+        )
+        
+        sr = ScanReport.objects.create(
+            data_partner = data_partner,
+            author = user,
+            name = "Foobar",
+            dataset = "Dataset A",
+            file = SimpleUploadedFile(
+                "best_file_eva.txt",
+                b"these are the file contents!"   # note the b in front of the string [bytes]
+            )
+        )
+        
+        srt=ScanReportTable.objects.create(
+            scan_report = sr,
+            name = "ScanReport Table"
+        )
+        
+        srf=ScanReportField.objects.create(
+            scan_report_table = srt,
+            name = "Test",
+            description_column = "Test Field",
+            type_column = "VARCHAR",
+            max_length = 32,
+            nrows = 1,   
+            nrows_checked = 1,
+            fraction_empty = 50.85,
+            nunique_values = 100,
+            fraction_unique = 12.5,
+            ignore_column = False,
+            is_patient_id = False,
+            is_date_event = False,
+            is_ignore = False,
+            classification_system = None,
+            date_type = "DOB",
+            concept_id = None
+        )
+        
+        srv=ScanReportValue.objects.create(
+            scan_report_field = srf,
+            value = "12345",
+            frequency = 5,
+            conceptID = -1
+        )
+        
+        obj = DataDictionary.objects.create(
+            source_value=srv,
+            dictionary_table="Table A",
+            dictionary_field="Field B",
+            dictionary_field_description="Field A Description",
+            dictionary_value_code="12345",
+            dictionary_value_description="12345 value description",
+            definition_fixed=True
+   
+        )
+        
+        qs = DataDictionary.objects.all()
+        print('TYPE >>> ', type(qs))
 
-        # GET
-        get_response = requests.get(response.headers['operation-location'], headers=headers)
-        x = get_response.json()
-        print(json.dumps(x, indent=4))
+        # Create a concat field for NLP to work from
+        # V is imported from models, used to comma separate other fields
+        qs = qs.annotate(
+            nlp_string=Concat(
+                "source_value__scan_report_field__name",
+                V(", "),
+                "source_value__value",
+                V(", "),
+                "dictionary_field_description",
+                V(", "),
+                "dictionary_value_description",
+                output_field=CharField(),
+            )
+        )
+   
+        # Create object to convert to JSON
+        for_json = qs.values(
+            "id",
+            "source_value__value",
+            "source_value__scan_report_field__name",
+            "nlp_string",
+        )
+
+        print(for_json)
+        
+        # qs_json = serializers.serialize('json', for_json)
+        # print(qs_json)
+        
+        
+        # # POST
+        # url = "https://ccnett2.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/health/jobs?stringIndexType=TextElements_v8"
+        # payload = '{\n  "documents": [\n    {\n      "language": "en",\n      "id": "source_field",\n      "text": "Headache"\n    }\n  ]\n}'
+        # headers = {
+        #     "Ocp-Apim-Subscription-Key": os.environ.get("NLP_API_KEY"),
+        #     "Content-Type": "application/json; utf-8",
+        # }
+
+        # response = requests.post(url, headers=headers, data=payload)
+        # print("POST STATUS CODE >>> ", response.status_code)
+
+        # # Add a short artificial wait to give the NLP service
+        # # time to run the job
+        # print('Short artifical wait...')
+        # time.sleep(5)
+
+        # # GET
+        # get_response = requests.get(
+        #     response.headers["operation-location"], headers=headers
+        # )
+        # print('GET STATUS CODE >>> ', get_response.status_code)
+        # x = get_response.json()
+        # print(x.items())
+
+        # for item in x.items():
+        #     print(item)
+        #     print(type(item))
+            
+        # for key, value in x.items():
+        #     print(key, '->', value)
+            
+        # print(type(x['results']))
+        # print(x['results'].items())
+        # print(x['results'].keys())
+        
+        # print(type(x['results']['documents']))
+        # print(x['results']['documents'][1])
+        
+
+        # print(json.dumps(x, indent=4))

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from .services import process_scan_report_sheet_table, build_usagi_index, run_usagi
 import time, requests, os, json, math
+import pandas as pd
 
 from .models import ScanReport, DataPartner, ScanReportTable, ScanReportField, ScanReportValue, DataDictionary
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -132,9 +133,9 @@ class ServiceTests(TestCase):
             source_value=srv3,
             dictionary_table="PatientSymptoms",
             dictionary_field="Symptom",
-            dictionary_field_description="Occupation",
-            dictionary_value_code="Janitor",
-            dictionary_value_description="Staff Occupation",
+            dictionary_field_description="What symptom the patient is experiencing",
+            dictionary_value_code="Yes",
+            dictionary_value_description="Sore throat",
             definition_fixed=True
    
         )
@@ -205,10 +206,7 @@ class ServiceTests(TestCase):
                 time.sleep(3)
             else:
                 get_response.append(job['results'])
-                print("Completed! \n")
-                
-        print(get_response)
-        
+                print("Completed! \n")        
         
         codes = []
         keep = ['ICD9','ICD10','SNOMEDCT_US']

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -116,6 +116,13 @@ class ServiceTests(TestCase):
             conceptID = -1
         )
         
+        srv5=ScanReportValue.objects.create(
+            scan_report_field = srf,
+            value = "Janitor",
+            frequency = 5,
+            conceptID = -1
+        )
+        
         DataDictionary.objects.create(
             source_value=srv1,
             dictionary_table="PatientSymptoms",
@@ -158,7 +165,18 @@ class ServiceTests(TestCase):
                 dictionary_value_description="Joint pain",
                 definition_fixed=True
     
-            )
+        )
+        
+        DataDictionary.objects.create(
+                source_value=srv4,
+                dictionary_table="Occupation",
+                dictionary_field="Occupation",
+                dictionary_field_description="Staff member occupation",
+                dictionary_value_code="Yes",
+                dictionary_value_description="Janitor",
+                definition_fixed=True
+    
+        )
         
         
         qs = DataDictionary.objects.all()

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -188,16 +188,16 @@ class ServiceTests(TestCase):
             chunk = {"documents":documents[i:i+chunk_size]}
             payload = json.dumps(chunk)
             response = requests.post(url, headers=headers, data=payload)
-            print(chunk, ' - ', response.status_code, response.reason)
+            print(response.status_code, response.reason)
             post_response_url.append(response.headers["operation-location"])
             time.sleep(5)
             
         # GET the response
         get_response = []
-        for i in post_response_url:
+        for url in post_response_url:
         
-            print('PROCESSING JOB >>>', i, '\n')
-            req = requests.get(i, headers=headers)
+            print('PROCESSING JOB >>>', url, '\n')
+            req = requests.get(url, headers=headers)
             job = req.json()
             
             while job['status'] == "notStarted":

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -201,46 +201,11 @@ class ServiceTests(TestCase):
             job = req.json()
             
             while job['status'] == "notStarted":
+                req = requests.get(url, headers=headers)
                 print("Waiting...")
                 time.sleep(2)
             else:
-                print('JOB RESULT >>> ', job['results'])
+                get_response.append(job['results'])
                 print("Completed!")
-        
-        # print('THE RESPONSE >>> ', get_response)
-            
-            # my_json = req.content.decode('utf8').replace("'", '"')
-            # data = json.loads(req.content)
-            # s = json.dumps(data, indent=4, sort_keys=True)
-            # print(s)
-                            
-     
-        # POST
-        # url = "https://ccnett2.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/health/jobs?stringIndexType=TextElements_v8"
-        # payload = json.dumps({"documents":documents})
-        # headers = {
-        #     "Ocp-Apim-Subscription-Key": os.environ.get("NLP_API_KEY"),
-        #     "Content-Type": "application/json; utf-8",
-        # }
-
-        # response = requests.post(url, headers=headers, data=payload)
-        # print("POST STATUS CODE >>> ", response.status_code)
-        # print("POST REASON >>> ", response.reason)
-        # print(dir(response))
-
-        # # Add a short artificial wait to give the NLP service
-        # # time to run the job
-        # print('Short artifical wait...')
-        # time.sleep(10)
-
-        # # # GET
-        # get_response = requests.get(
-        #     response.headers["operation-location"], headers=headers
-        # )
-        # print('GET STATUS CODE >>> ', get_response.status_code)
-        # x = get_response.json()
-        # print(x.items())
-
-
-
-        # print(json.dumps(x, indent=4))
+                
+        print(get_response)

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -12,6 +12,8 @@ from django.db.models.functions import Concat
 from django.db.models import CharField, Value as V
 from django.forms.models import model_to_dict
 
+import coconnect
+from coconnect.tools.omop_db_inspect import OMOPDetails
 
 class ServiceTests(TestCase):
     def test_process_scan_report_sheet_table(self):
@@ -209,9 +211,7 @@ class ServiceTests(TestCase):
             else:
                 get_response.append(job['results'])
                 print("Completed! \n")    
-                    
-        print(get_response)
-        
+                            
         codes = []
         keep = ['ICD9','ICD10','SNOMEDCT_US']
         
@@ -226,3 +226,10 @@ class ServiceTests(TestCase):
                                 
         codes_df = pd.DataFrame(codes,columns=['key', 'entity', 'category', 'confidence', 'vocab', 'code'])
         print(codes_df)
+        
+      
+    def test_get_omop(self):
+    
+        omop_lookup = OMOPDetails()
+        x = omop_lookup.get_rules(386661006)
+        print(x)        

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -161,6 +161,8 @@ class ServiceTests(TestCase):
             "source_value__scan_report_field__name",
             "nlp_string",
         )
+        
+        print(for_json)
     
         # Translate queryset into JSON-like dict for NLP
         documents = []
@@ -206,7 +208,9 @@ class ServiceTests(TestCase):
                 time.sleep(3)
             else:
                 get_response.append(job['results'])
-                print("Completed! \n")        
+                print("Completed! \n")    
+                    
+        print(get_response)
         
         codes = []
         keep = ['ICD9','ICD10','SNOMEDCT_US']

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -229,7 +229,6 @@ class ServiceTests(TestCase):
         
       
     def test_get_omop(self):
-    
         omop_lookup = OMOPDetails()
-        x = omop_lookup.get_rules(386661006)
+        x = omop_lookup.lookup_code("R50.9")
         print(x)        

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -209,11 +209,16 @@ class ServiceTests(TestCase):
                 
         print(get_response)
         
+        
+        codes = []
+        keep = ['ICD9','ICD10','SNOMEDCT_US']
         # Mad nested for loops to get at the data in the response
         for url in get_response:
             for dict_entry in url['documents']:
                 for entity in dict_entry['entities']:
                     if 'links' in entity.keys():
                         for link in entity['links']:
-                            print(entity['text'],link)
-                            
+                            if link['dataSource'] in keep:
+                                codes.append([dict_entry['id'], entity['text'], link['dataSource'], link['id']])
+                                
+        print(codes)

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -32,3 +32,26 @@ class ServiceTests(TestCase):
     def test_run_usagi(self):
         x = run_usagi()
         print(x)
+        
+    def test_nlp(self):
+    
+        # POST 
+        url = "https://ccnett2.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/health/jobs?stringIndexType=TextElements_v8"
+        payload="{\n  \"documents\": [\n    {\n      \"language\": \"en\",\n      \"id\": \"source_field\",\n      \"text\": \"Headache\"\n    }\n  ]\n}"            
+        headers = {
+            'Ocp-Apim-Subscription-Key': os.environ.get('NLP_API_KEY'),
+            'Content-Type': 'application/json; utf-8'
+        }
+
+        response = requests.post(url, headers=headers, data=payload)
+        print('POST STATUS CODE >>> ', response.status_code)
+        print('HEADERS >>> ', response.headers)
+        
+        # Add a short artificial wait to give the NLP service
+        # time to run the job
+        time.sleep(5)
+
+        # GET
+        get_response = requests.get(response.headers['operation-location'], headers=headers)
+        x = get_response.json()
+        print(json.dumps(x, indent=4))

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -9,8 +9,7 @@ from django.conf import settings
 from django.core import serializers
 from django.db.models.functions import Concat
 from django.db.models import CharField, Value as V
-
-
+from django.forms.models import model_to_dict
 
 
 class ServiceTests(TestCase):
@@ -40,6 +39,7 @@ class ServiceTests(TestCase):
         x = run_usagi()
         print(x)
 
+    # Run this to get data back from Azure NLP for Health Services
     def test_nlp(self):
         
         user = User.objects.get_or_create(
@@ -62,12 +62,12 @@ class ServiceTests(TestCase):
         
         srt=ScanReportTable.objects.create(
             scan_report = sr,
-            name = "ScanReport Table"
+            name = "Occupation"
         )
         
         srf=ScanReportField.objects.create(
             scan_report_table = srt,
-            name = "Test",
+            name = "Occupation",
             description_column = "Test Field",
             type_column = "VARCHAR",
             max_length = 32,
@@ -87,24 +87,23 @@ class ServiceTests(TestCase):
         
         srv=ScanReportValue.objects.create(
             scan_report_field = srf,
-            value = "12345",
+            value = "Clinical Nurse",
             frequency = 5,
             conceptID = -1
         )
         
         obj = DataDictionary.objects.create(
             source_value=srv,
-            dictionary_table="Table A",
-            dictionary_field="Field B",
-            dictionary_field_description="Field A Description",
-            dictionary_value_code="12345",
-            dictionary_value_description="12345 value description",
+            dictionary_table="Occupation",
+            dictionary_field="Occupation",
+            dictionary_field_description="The occupation of the staff member",
+            dictionary_value_code="Clinical Nurse",
+            dictionary_value_description="This member of staff id a clinical nurse",
             definition_fixed=True
    
         )
         
         qs = DataDictionary.objects.all()
-        print('TYPE >>> ', type(qs))
 
         # Create a concat field for NLP to work from
         # V is imported from models, used to comma separate other fields
@@ -120,7 +119,8 @@ class ServiceTests(TestCase):
                 output_field=CharField(),
             )
         )
-   
+    
+        
         # Create object to convert to JSON
         for_json = qs.values(
             "id",
@@ -129,49 +129,59 @@ class ServiceTests(TestCase):
             "nlp_string",
         )
 
-        print(for_json)
+        print('QUERYSET FOR JSON >>> ', for_json)
         
-        # qs_json = serializers.serialize('json', for_json)
-        # print(qs_json)
+        documents = []
         
+        for row in for_json:
+            documents.append({
+                'language':'en',
+                'id':row['id'],
+                'text':row['nlp_string']
+            })
+            
+        print({"documents":documents})
         
-        # # POST
-        # url = "https://ccnett2.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/health/jobs?stringIndexType=TextElements_v8"
-        # payload = '{\n  "documents": [\n    {\n      "language": "en",\n      "id": "source_field",\n      "text": "Headache"\n    }\n  ]\n}'
-        # headers = {
-        #     "Ocp-Apim-Subscription-Key": os.environ.get("NLP_API_KEY"),
-        #     "Content-Type": "application/json; utf-8",
+        # What the JSON to MS NLP needs to look like
+        # using the above queryset as an example input string
+        
+        # {
+        # "documents": [
+        #     {
+        #     "language": "en",
+        #     "id": "1", 
+        #     "text": "Occupation, Clinical Nurse, The occupation of the staff member, This member of staff id a clinical nurse"
+        #     }
+        # ]
         # }
+        
+        
+        # POST
+        url = "https://ccnett2.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/health/jobs?stringIndexType=TextElements_v8"
+        payload = json.dumps({"documents":documents})
+        headers = {
+            "Ocp-Apim-Subscription-Key": os.environ.get("NLP_API_KEY"),
+            "Content-Type": "application/json; utf-8",
+        }
 
-        # response = requests.post(url, headers=headers, data=payload)
-        # print("POST STATUS CODE >>> ", response.status_code)
+        response = requests.post(url, headers=headers, data=payload)
+        print("POST STATUS CODE >>> ", response.status_code)
+        print("POST REASON >>> ", response.reason)
+        print(dir(response))
 
-        # # Add a short artificial wait to give the NLP service
-        # # time to run the job
-        # print('Short artifical wait...')
-        # time.sleep(5)
+        # Add a short artificial wait to give the NLP service
+        # time to run the job
+        print('Short artifical wait...')
+        time.sleep(10)
 
         # # GET
-        # get_response = requests.get(
-        #     response.headers["operation-location"], headers=headers
-        # )
-        # print('GET STATUS CODE >>> ', get_response.status_code)
-        # x = get_response.json()
-        # print(x.items())
+        get_response = requests.get(
+            response.headers["operation-location"], headers=headers
+        )
+        print('GET STATUS CODE >>> ', get_response.status_code)
+        x = get_response.json()
+        print(x.items())
 
-        # for item in x.items():
-        #     print(item)
-        #     print(type(item))
-            
-        # for key, value in x.items():
-        #     print(key, '->', value)
-            
-        # print(type(x['results']))
-        # print(x['results'].items())
-        # print(x['results'].keys())
-        
-        # print(type(x['results']['documents']))
-        # print(x['results']['documents'][1])
-        
+
 
         # print(json.dumps(x, indent=4))

--- a/api/mapping/test_services.py
+++ b/api/mapping/test_services.py
@@ -212,6 +212,7 @@ class ServiceTests(TestCase):
         
         codes = []
         keep = ['ICD9','ICD10','SNOMEDCT_US']
+        
         # Mad nested for loops to get at the data in the response
         for url in get_response:
             for dict_entry in url['documents']:
@@ -219,6 +220,7 @@ class ServiceTests(TestCase):
                     if 'links' in entity.keys():
                         for link in entity['links']:
                             if link['dataSource'] in keep:
-                                codes.append([dict_entry['id'], entity['text'], link['dataSource'], link['id']])
+                                codes.append([dict_entry['id'], entity['text'], entity['category'], entity['confidenceScore'], link['dataSource'], link['id']])
                                 
-        print(codes)
+        codes_df = pd.DataFrame(codes,columns=['key', 'entity', 'category', 'confidence', 'vocab', 'code'])
+        print(codes_df)

--- a/docker/django/requirements.txt
+++ b/docker/django/requirements.txt
@@ -10,6 +10,7 @@ psycopg2
 djangorestframework
 markdown
 django-filter
+requests
 
 #for coconnect tools, installing here speeds up docker build
 numpy


### PR DESCRIPTION
This PR adds a lot of code to test_services.py
Calling `docker-compose exec api python manage.py test mapping.test_services.ServiceTests.test_get_omop` will run the test and output a pandas dataframe of cleaned results from the NLP service.

This update requires an update to coconnect tools submodule within /mapping-pipeline, so don't forget to `git pull origin master` within the co-connect-tools dir in the mapping-tools repo.