### PR TITLE
[IMPORTANT] Fix postgres db image tag, to keep consistency 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         max-file: "10"
 
   db:
-    image: postgres
+    image: postgres:13.1
     restart: unless-stopped
     env_file:
       - .env


### PR DESCRIPTION
I found that the postgres running on the ccnettestdb or on the VM might be different from what starts running if you spin up the docker-compose locally where the postgres docker images is just taking `postgres:latest` 