### PR TITLE
[IMPORTANT] bump up django version

### DIFF
--- a/docker/django/requirements.txt
+++ b/docker/django/requirements.txt
@@ -1,4 +1,4 @@
-django==3.1.9
+django==3.1.12
 redis
 celery
 pandas

--- a/docker/django/requirements.txt
+++ b/docker/django/requirements.txt
@@ -1,4 +1,4 @@
-django==3.1.8
+django==3.1.9
 redis
 celery
 pandas


### PR DESCRIPTION
django 3.1.8 is vulnerable 
https://dev.azure.com/UniversityOfNottingham/DRS/_backlogs/backlog/CO-CONNECT/Features/?workitem=36495