### PR TITLE
Setting up configuration to be able to use multiple databases

### DIFF
--- a/api/api/routers.py
+++ b/api/api/routers.py
@@ -1,0 +1,30 @@
+class OmopRouter:
+    """
+    A router to control all database operations on models in the
+    Omop database
+    """
+    #we have two seperate database objects, which we can separate:
+    # - api/mapping
+    #   - where we have ScanReport Objects eg. ScanReportValue
+    # - api/data
+    #   - where we have Omop Objects e.g. Concept
+
+    #define a look up between the "data" api models
+    #and the omop database which is defined in
+    # settings.py under DATABASES = { 'omop': ... }
+    route_app_labels = { 'data': 'omop' }
+
+    #overload the function for where to read the database from
+    def db_for_read(self, model, **hints):
+        """
+        Attempts to read data models go to omop db
+        """
+        #if the app label is in route_app_labels
+        if model._meta.app_label in self.route_app_labels:
+            #for which it will be for the data models (Concept, ConceptRelationShip...)
+            #tell django to read from this database instead 
+            return self.route_app_labels[model._meta.app_label]
+        #otherwise None will handle as normal
+        #i.e. to read from 'default' database that is defined in settings.py
+        return None
+

--- a/api/api/routers.py
+++ b/api/api/routers.py
@@ -2,6 +2,9 @@ class OmopRouter:
     """
     A router to control all database operations on models in the
     Omop database
+
+    https://docs.djangoproject.com/en/3.2/topics/db/multi-db/
+
     """
     #we have two seperate database objects, which we can separate:
     # - api/mapping

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -98,15 +98,14 @@ DATABASES = {
         'PASSWORD': os.getenv('COCONNECT_DB_PASSWORD'),
     },
     'omop': {
-        'ENGINE': os.getenv('OMOP_POSTGRES_ENGINE'),
-        'HOST': os.getenv('OMOP_POSTGRES_HOST'),
-        'USER': os.getenv('OMOP_POSTGRES_USER'),
-        'PASSWORD': os.getenv('OMOP_POSTGRES_PASSWORD'),
-        'PORT': os.getenv('OMOP_POSTGRES_PORT'),
-        'NAME':  os.getenv('OMOP_POSTGRES_DB')
+        'ENGINE': os.getenv('OMOP_DB_ENGINE'),
+        'HOST': os.getenv('OMOP_DB_HOST'),
+        'PORT': os.getenv('OMOP_DB_PORT'),
+        'NAME':  os.getenv('OMOP_DB_NAME'),
+        'USER': os.getenv('OMOP_DB_USER'),
+        'PASSWORD': os.getenv('OMOP_DB_PASSWORD'),
     }
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
@@ -125,6 +124,8 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+DATABASE_ROUTERS = ['api.routers.OmopRouter']
 
 
 # Internationalization

--- a/api/data/models/concept_relationship.py
+++ b/api/data/models/concept_relationship.py
@@ -31,4 +31,6 @@ class ConceptRelationship(models.Model):
     class Meta:
         managed = False
         db_table = 'omop"."concept_relationship'
+        app_label = 'omop'
         unique_together = (('concept_id_1', 'concept_id_2', 'relationship_id'),)
+        


### PR DESCRIPTION
depends on #143, #142 and #137

allows users to separate out the OMOP database from the online database