### PR TITLE
Fix/catch error when concept not found

### DIFF
--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -77,10 +77,14 @@ def get_concept_from_concept_code(concept_code,
 
 def find_standard_concept(source_concept):
 
-    concept_relation = ConceptRelationship.objects.get(
-        concept_id_1=source_concept.concept_id,
-        relationship_id__contains='Maps to'
-    )
+    try:
+        concept_relation = ConceptRelationship.objects.get(
+            concept_id_1=source_concept.concept_id,
+            relationship_id__contains='Maps to'
+        )
+    except ConceptRelationship.DoesNotExist:
+        return None
+        
 
     if concept_relation.concept_id_2 != concept_relation.concept_id_1:
         concept = Concept.objects.get(

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -62,7 +62,6 @@ from django.core.mail import BadHeaderError, send_mail
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import CharField
 from django.db.models import Value as V
-from django.db.models import DoesNotExist 
 from django.db.models.functions import Concat
 from django.db.models.query_utils import Q
 from django.http import HttpResponse
@@ -1066,17 +1065,17 @@ def validate_standard_concept(request,source_concept):
                            source_concept.concept_id,
                            source_concept.concept_name)
         )
-        try:
-            concept = find_standard_concept(source_concept)
+        concept = find_standard_concept(source_concept)
+        if concept == None:
+            messages.error(request,
+                           "No associated Standard Concept could be found for this!")
+        else:
             messages.error(request,
                            "You could try {} ({}) ?".format(
                                concept.concept_id,
                                concept.concept_name)
             )
-        except DoesNotExist:
-            messages.error(request,
-                           "No associated Standard Concept could be found for this!"
-            )
+            
         return False
     
 def pass_content_object_validation(request,scan_report_table):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -62,6 +62,7 @@ from django.core.mail import BadHeaderError, send_mail
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import CharField
 from django.db.models import Value as V
+from django.db.models import DoesNotExist 
 from django.db.models.functions import Concat
 from django.db.models.query_utils import Q
 from django.http import HttpResponse
@@ -1065,14 +1066,17 @@ def validate_standard_concept(request,source_concept):
                            source_concept.concept_id,
                            source_concept.concept_name)
         )
-        
-        concept = find_standard_concept(source_concept)
-        messages.error(request,
-                       "You could try {} ({}) ?".format(
-                           concept.concept_id,
-                           concept.concept_name)
-        )
-        
+        try:
+            concept = find_standard_concept(source_concept)
+            messages.error(request,
+                           "You could try {} ({}) ?".format(
+                               concept.concept_id,
+                               concept.concept_name)
+            )
+        except DoesNotExist:
+            messages.error(request,
+                           "No associated Standard Concept could be found for this!"
+            )
         return False
     
 def pass_content_object_validation(request,scan_report_table):


### PR DESCRIPTION
In the new functionality when a Non-Standard concept is added, the code looks up what is the associated Standard Concept and suggests that the user can use that one instead.

However, if a Non-Standard concept is added but the ConceptRelationship look up fails, a django error is thrown.

This should be a very rare case (or indicates something is incomplete in our Omop DB - unlikely)

Example: `4185920`

## Before Fix

![image](https://user-images.githubusercontent.com/69473770/121659736-7fa18c00-ca9a-11eb-8129-b293b42c786d.png)

throws the error:
![image](https://user-images.githubusercontent.com/69473770/121659781-8af4b780-ca9a-11eb-9493-961a2ace7d76.png)

----------


# After Fix

![image](https://user-images.githubusercontent.com/69473770/121659858-9fd14b00-ca9a-11eb-8203-2f86320e1458.png)





