### PR TITLE
Pin Azure/functions-action to v1.3.2

### DIFF
--- a/.github/workflows/devel_ccom-func-dev.yml
+++ b/.github/workflows/devel_ccom-func-dev.yml
@@ -34,12 +34,10 @@ jobs:
         popd
 
     - name: 'Run Azure Functions Action'
-      uses: Azure/functions-action@v1
+      uses: Azure/functions-action@v1.3.2
       id: fa
       with:
         app-name: 'ccom-funcs-dev'
         slot-name: 'production'
         package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
         publish-profile: ${{ secrets.AZURE_FUNCAPP_PUBLISH_PROFILE }}
-        scm-do-build-during-deployment: true
-        enable-oryx-build: true


### PR DESCRIPTION
to avoid the repeated failure to sync settings to kudu container. Revert setting of scm-do-build-during-deployment=true and enable-oryx-build=true.