### PR TITLE
Update/submodule usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
      - name: Run the docker image
        run: |
          #startup the stack
-         docker run -t --env-file .env -p 8080:8000 ccom-build:latest
+         docker run -t --env-file .env -p 8080:8000 -d ccom-build:latest
          #give it 30s to start properly
          sleep 30s
          #get container ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,10 @@ jobs:
        run: |
          #startup the stack
          docker run -it --env-file .env -p 8080:8000 -d ccom-build:latest
-         #give it 60s to start properly
-         sleep 60s
+         #give it 30s to start properly
+         sleep 30s
+         docker ps
+         docker ps | awk 'NR==2'
          #get container ID
          containerid=$(docker ps | awk 'NR==2' | awk '{print $1;}')
          echo $containerid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
      - name: Run the docker image
        run: |
          #startup the stack
-         docker run -t --env-file .env -p 8080:8000 -d ccom-build:latest
+         docker run -it --env-file .env -p 8080:8000 -d ccom-build:latest
          #give it 30s to start properly
          sleep 30s
          #get container ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,10 @@ jobs:
      - name: Run the docker image
        run: |
          #startup the stack
-         docker run -it --env-file .env -p 8080:8000 -d ccom-build:latest
+         docker run -it --env-file .env -p 8080:8000 ccom-build:latest
          #give it 30s to start properly
          sleep 30s
          docker ps
-         docker ps | awk 'NR==2'
          #get container ID
          containerid=$(docker ps | awk 'NR==2' | awk '{print $1;}')
          echo $containerid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
          echo COCONNECT_DB_PORT=${{ secrets.COCONNECT_DB_PORT }} >> .env
          echo COCONNECT_DB_PASSWORD=${{ secrets.COCONNECT_DB_PASSWORD }} >> .env
          echo COCONNECT_DB_USER=${{ secrets.COCONNECT_DB_USER }} >> .env
-         echo SECRET_KEY=${{ secrets.SECRET_KEY }} >> .env
+         echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
 
      - name: Build the docker image
        run: docker build -t ccom-build:latest .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
        run: |
          #startup the stack
          docker run -it --env-file .env -p 8080:8000 -d ccom-build:latest
-         #give it 30s to start properly
-         sleep 30s
+         #give it 60s to start properly
+         sleep 60s
          #get container ID
          containerid=$(docker ps | awk 'NR==2' | awk '{print $1;}')
          echo $containerid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,9 @@ jobs:
      - name: Run the docker image
        run: |
          #startup the stack
-         docker run -it --env-file .env -p 8080:8000 ccom-build:latest
+         docker run -t --env-file .env -p 8080:8000 ccom-build:latest
          #give it 30s to start properly
          sleep 30s
-         docker ps
          #get container ID
          containerid=$(docker ps | awk 'NR==2' | awk '{print $1;}')
          echo $containerid

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "co-connect-tools"]
-	path = co-connect-tools
-	url = https://github.com/CO-CONNECT/co-connect-tools.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,6 @@ RUN pip install -r /api/requirements.txt --no-cache-dir
 USER root
 RUN apt-get install graphviz -y
 
-COPY --chown=django:django co-connect-tools/ /coconnect/
-
 USER django
-
-RUN pip install -e /coconnect/
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
         binutils \
         gettext \
         libpq-dev \
-        gcc
+        gcc \
+	graphviz
 
 RUN addgroup -q django && \
     adduser --quiet --ingroup django --disabled-password django
@@ -33,10 +34,5 @@ USER django
 ENV PATH=/home/django/.local/bin:$PATH
 
 RUN pip install -r /api/requirements.txt --no-cache-dir
-
-USER root
-RUN apt-get install graphviz -y
-
-USER django
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
         wait-for-it \
         binutils \
         gettext \
-        libpq-dev \
-        gcc \
+	libpq-dev \
+	gcc \
 	graphviz
 
 RUN addgroup -q django && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && \
         wait-for-it \
         binutils \
         gettext \
-	libpq-dev \
-	gcc \
-	graphviz
+        libpq-dev \
+        gcc \
+        graphviz
 
 RUN addgroup -q django && \
     adduser --quiet --ingroup django --disabled-password django

--- a/api/mapping/services.py
+++ b/api/mapping/services.py
@@ -17,9 +17,6 @@ from .models import (
     DataDictionary
 )
 
-from coconnect.tools.omop_db_inspect import OMOPDetails
-
-
 
 def get_concept_from_concept_code(concept_code,
                                   vocabulary_id,

--- a/api/mapping/services_nlp.py
+++ b/api/mapping/services_nlp.py
@@ -6,7 +6,6 @@ import time
 from azure.storage.queue import QueueClient
 
 import requests
-from coconnect.tools.omop_db_inspect import OMOPDetails
 from data.models import Concept, ConceptRelationship
 from django.db.models import Q
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,11 +13,4 @@ django-filter
 requests
 django-storages[azure]
 azure-storage-queue==12.1.6
-
-#for coconnect tools, installing here speeds up docker build
-numpy
-coloredlogs
-Jinja2
-graphviz
-click
-sqlalchemy
+co-connect-tools==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ azure-storage-blob==2.1.0
 requests
 openpyxl
 datetime
+co-connect-tools==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ azure-storage-blob==2.1.0
 requests
 openpyxl
 datetime
-co-connect-tools==0.2.5


### PR DESCRIPTION
We shouldnt be needing to rely on the co-connect-tools submodule anymore, this adds complication.

OmopDetails is a class that has been long redundant, so it is removed in services.py 

Since we still use `coconnect.tools.make_dag()` function, we install `co-connect-tools` via pip instead 