### PR TITLE
functionality to generate synthetic data from a scan report

### DIFF
--- a/api/mapping/management/commands/synthetic.py
+++ b/api/mapping/management/commands/synthetic.py
@@ -7,11 +7,15 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--id', required=True, type=int)
         parser.add_argument('--number-of-events', required=True, type=int)
+        parser.add_argument('-o','--output-folder',default='',type=str)
                             
     def handle(self, *args, **options):
         request = None
         _id = options['id']
         number_of_events = options['number_of_events']
+        output_folder = options['output_folder']
         
-        generate_synthetic_data_report(scan_report_id=_id,number_of_events=number_of_events)
+        generate_synthetic_data_report(scan_report_id=_id,
+                                       number_of_events=number_of_events,
+                                       output_folder=output_folder)
         

--- a/api/mapping/management/commands/synthetic.py
+++ b/api/mapping/management/commands/synthetic.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand, CommandError
+from mapping.services_synthetic_data import generate_synthetic_data_report
+
+
+class Command(BaseCommand):
+    help = 'create rules from exisiting concepts found for a given table id'
+    def add_arguments(self, parser):
+        parser.add_argument('--id', required=True, type=int)
+        parser.add_argument('--number-of-events', required=True, type=int)
+                            
+    def handle(self, *args, **options):
+        request = None
+        _id = options['id']
+        number_of_events = options['number_of_events']
+        
+        generate_synthetic_data_report(scan_report_id=_id,number_of_events=number_of_events)
+        

--- a/api/mapping/services_synthetic_data.py
+++ b/api/mapping/services_synthetic_data.py
@@ -11,8 +11,9 @@ import os
 def generate_synthetic_data_table(scan_report_table_id: int, number_of_events: int) -> pd.DataFrame:
 
     table = ScanReportTable.objects.get(pk=scan_report_table_id)
-
-    field_person_id = ScanReportField.objects.get(pk=table.person_id.id).name
+    field_person_id = None
+    if table.person_id is not None:
+        field_person_id = ScanReportField.objects.get(pk=table.person_id.id).name
     
     #get all columns (fields) for a given table 
     fields = ScanReportField.objects\

--- a/api/mapping/services_synthetic_data.py
+++ b/api/mapping/services_synthetic_data.py
@@ -1,0 +1,81 @@
+from mapping.models import (
+    ScanReport,
+    ScanReportTable,
+    ScanReportField,
+    ScanReportValue
+)
+import json
+import pandas as pd
+
+def generate_synthetic_data_table(scan_report_table_id: int, number_of_events: int) -> pd.DataFrame:
+
+    table = ScanReportTable.objects.get(pk=scan_report_table_id)
+
+    field_person_id = ScanReportField.objects.get(pk=table.person_id.id).name
+    
+    #get all columns (fields) for a given table 
+    fields = ScanReportField.objects\
+                                .filter(scan_report_table=table)\
+                                .order_by("created_at")
+
+    #create an array to hold each pandas series
+    #corresponding to a synthetic data column
+    series_synthetic = []
+    #loop over all columns (fields) in the table
+    for field in fields:
+        #obtain all values there are in the ScanReport
+        objects = ScanReportValue.objects.filter(scan_report_field=field)
+        #pull out data for each value giving the raw value and the frequency of this value
+        data = [
+            {field.name:obj.value,'frequency':obj.frequency}
+            for obj in objects
+        ]
+        #build a temporary dataframe from this
+        df = pd.DataFrame.from_records(data)
+        #get all the frequencies
+        frequency = df['frequency']
+        #normalise the frequency by total recorded
+        norm_frequency = frequency / frequency.sum()
+        #for each value work out how many times the value must be repeated
+        #in order to generate the number_of_events requested
+        n_generate = number_of_events*norm_frequency
+        #round this number to an integer
+        n_generate = n_generate.astype(int)
+        
+        
+        # 1. take the values, which is the first column in this temp df
+        #    the 2nd column is the frequency
+        # 2. repeat them the number of times needed to generate number_of_events
+        # 3. randomly sample them, to mix up and shuffle the values in the column
+        # 4. remove the index so that we just have the synthetic value we want
+        values = df.iloc[:,0]\
+            .loc[df.index.repeat(n_generate)]\
+            .sample(frac=1)\
+            .reset_index(drop=True)
+        
+        #append this to the list
+        series_synthetic.append(values)
+
+    #merge all columns together to create a new table
+    df_synthetic = pd.concat(series_synthetic,axis=1)
+
+    if field_person_id in df_synthetic.columns:
+        df_synthetic[field_person_id] = df_synthetic.reset_index()['index']
+        
+    
+    #return this synthetic data table
+    return df_synthetic
+
+    
+
+def generate_synthetic_data_report(scan_report_id,number_of_events):
+    scan_report = ScanReport.objects.get(pk=scan_report_id)
+    #get all tables for the given dataset (via scanreport id)
+    tables = ScanReportTable.objects.filter(scan_report=scan_report)
+    #loop over all tables within the dataset
+    for table in tables:
+        #generate synthetic data in the form of a dataframe for them
+        df = generate_synthetic_data_table(table.id,number_of_events)
+        #print (scan_report.data_partner.name,scan_report.dataset,table.name)
+        print (df)
+        df.to_csv(f"{table.name}",index=False)


### PR DESCRIPTION
* WhiteRabbit is too crap for generating large datasets
    * it will crash from running out of memory 
* Generating synthetic data from our django db will actually allow us to link up what `person_id` columns across tables since these are marked by the data team
    * with WhiteRabbit synthetic data, there is now way of telling that columnA in tableA should be linked with columnB in tableB because they're both  the person_id 