### PR TITLE
Env vars for Azure Functions queues

### DIFF
--- a/NLPQueue/function.json
+++ b/NLPQueue/function.json
@@ -5,7 +5,7 @@
       "name": "msg",
       "type": "queueTrigger",
       "direction": "in",
-      "queueName": "NLP_QUEUE_NAME",
+      "queueName": "%NLP_QUEUE_NAME%",
       "connection": "STORAGE_CONN_STRING"
     }
   ]

--- a/NLPQueue/function.json
+++ b/NLPQueue/function.json
@@ -5,7 +5,7 @@
       "name": "msg",
       "type": "queueTrigger",
       "direction": "in",
-      "queueName": "nlpqueue",
+      "queueName": "NLP_QUEUE_NAME",
       "connection": "STORAGE_CONN_STRING"
     }
   ]

--- a/ProcessQueue/function.json
+++ b/ProcessQueue/function.json
@@ -5,7 +5,7 @@
       "name": "msg",
       "type": "queueTrigger",
       "direction": "in",
-      "queueName": "scanreports",
+      "queueName": "SCAN_REPORT_QUEUE_NAME",
       "connection": "STORAGE_CONN_STRING"
     }
   ]

--- a/ProcessQueue/function.json
+++ b/ProcessQueue/function.json
@@ -5,7 +5,7 @@
       "name": "msg",
       "type": "queueTrigger",
       "direction": "in",
-      "queueName": "SCAN_REPORT_QUEUE_NAME",
+      "queueName": "%SCAN_REPORT_QUEUE_NAME%",
       "connection": "STORAGE_CONN_STRING"
     }
   ]

--- a/api/mapping/services_nlp.py
+++ b/api/mapping/services_nlp.py
@@ -134,7 +134,7 @@ def start_nlp_field_level(search_term):
         # Send JSON payload to nlp-processing-queue in Azure
         queue = QueueClient.from_connection_string(
             conn_str=os.environ.get("STORAGE_CONN_STRING"),
-            queue_name="nlpqueue",
+            queue_name=os.environ.get("NLP_QUEUE_NAME"),
         )
         queue.send_message(base64_message)
         print(queue)
@@ -177,7 +177,7 @@ def start_nlp_field_level(search_term):
             # Send JSON payload to nlp-processing-queue in Azure
             queue = QueueClient.from_connection_string(
                 conn_str=os.environ.get("STORAGE_CONN_STRING"),
-                queue_name="nlpqueue"
+                queue_name=os.environ.get("NLP_QUEUE_NAME"),
             )
             queue.send_message(base64_message)
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -630,7 +630,7 @@ class ScanReportFormView(FormView):
         
         queue = QueueClient.from_connection_string(
             conn_str=os.environ.get("STORAGE_CONN_STRING"),
-            queue_name="scanreports"
+            queue_name=os.environ.get("SCAN_REPORT_QUEUE_NAME")
         )
         queue.send_message(base64_message)
         


### PR DESCRIPTION
This PR has been raised to fix a number of (very) frustrating issues that @vpnu and I have been experiencing when developing Azure Functions code. Its purpose is to enable sending of queue messages to `<queue-name>-local` rather than the deployed queue (i.e. `nlpqueue` and `scanreports`) when developing locally. Without this change, AzFunc code is being triggered unintentionally and by different users when running Azure CLI locally, which is slowing down development considerably.

The environment variables are (for local development):
```
NLP_QUEUE_NAME=nlpqueue-local
SCAN_REPORT_QUEUE_NAME=scanreports-local
```
And for live:
```
NLP_QUEUE_NAME=nlpqueue
SCAN_REPORT_QUEUE_NAME=scanreports
```

For this PR to deploy successfully everywhere, env vars need to be maintained in the following locations:

1. local.settings.json - A local file to hold Azure Function environment variables. Should point to `local`. Not tracked on Git!
2. Within the Azure Function App. Env Vars need to be set within the Azure Portal to the 'live' vars
3. Within the CCOM webapp, the .env file must include variables for 'live'

An example local.settings.json file will look like:
```
{
  "IsEncrypted": false,
  "Values": {
    "AzureWebJobsStorage": "REDACTED,
    "FUNCTIONS_WORKER_RUNTIME": "python",
    "STORAGE_CONN_STRING": "REDACTED",
    "NLP_API_KEY": "REDACTED",
    "APP_URL": "REDACTED",
    "AZ_FUNCTION_KEY": "REDACTED",
    "SCAN_REPORT_QUEUE_NAME": "scanreports-local",
    "NLP_QUEUE_NAME": "nlpqueue-local"

  }
}
```

After this change:

1. Local triggering of queues will add messages to `<queue-name>-local` only
2. Deployed version(s) of CCOM will submit jobs to the respective 'live' queues.
3. There will be clear demarcation between jobs submitted to development (local) queues and live queues, thus aiding bug fixing in the future.

Note that @vpnu will have to update views.py to point to the scan report queue when appropriate.