### PR TITLE
Allow hot-reload and mount in local development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
          echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
 
      - name: Build the docker image
-       run: docker build -t ccom-build:latest .
+       run: docker build -f Dockerfile.deploy -t ccom-build:latest .
      - name: Run the docker image
        run: |
          #startup the stack

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -23,7 +23,7 @@ jobs:
         password: ${{ secrets.REGISTRY_PASSWORD_DEV }}
 
     - run: |
-        docker build . -t ccomreg.azurecr.io/dev:${{ github.sha }}
+        docker build -f Dockerfile.deploy . -t ccomreg.azurecr.io/dev:${{ github.sha }}
         docker push ccomreg.azurecr.io/dev:${{ github.sha }}
 
     - uses: azure/webapps-deploy@v2

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -2,6 +2,7 @@ FROM python:3.8-slim
 LABEL authors="Roberto Santos"
 
 ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
 
 EXPOSE 8000
 
@@ -25,15 +26,13 @@ RUN chmod u+x /entrypoint.sh
 
 RUN chown -R django:django /entrypoint.sh
 
-RUN mkdir /api
+COPY ./api /api
 
 WORKDIR /api
 
 USER django
 
 ENV PATH=/home/django/.local/bin:$PATH
-
-COPY ./api/requirements.txt /api/requirements.txt
 
 RUN pip install -r /api/requirements.txt --no-cache-dir
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Copy .env file from Teams Software Team -> files -> .env to the root of project.
 docker build --tag <docker_image>:<tag> .
 
 # run the app
-docker run -it --env-file .env -p 8080:8000 <docker_image>
+docker run -it --volume $PWD/api:/api --env-file .env -p 8080:8000 <docker_image>
 
 ```
 


### PR DESCRIPTION
Add `Dockerfile.deploy` which is used in deployment exactly as before. Repurpose `Dockerfile` to be used in a local development setting, mounting the `api` directory as a volume at container run time. This is documented in the `README.md`.