### PR TITLE
Removed markdown dependency

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,7 +8,6 @@ django-select2
 django-extra-views
 psycopg2
 djangorestframework
-markdown
 django-filter
 requests
 django-storages[azure]


### PR DESCRIPTION
Removed markdown from requirements.txt
I can't see any places where it's called within the app, so I think this is the only trace of it!