### PR TITLE
set --noinput on collectstatic command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,8 @@ wait-for-it ${COCONNECT_DB_HOST}:${COCONNECT_DB_PORT} -- echo "Database is ready
 
 cd /api
 
-python /api/manage.py collectstatic
-ls -R /api/staticfiles
+python /api/manage.py collectstatic --noinput
+
 python /api/manage.py runserver 0.0.0.0:8000
 
 #while :; do echo 'Hit CTRL+C'; sleep 1; done


### PR DESCRIPTION
This is to stop the deployment failing because `staticfiles/` is not empty.