### PR TITLE
Shahzad api update july2021 specifying returning fields for scanreportvalues

### DIFF
--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_dynamic_fields import DynamicFieldsMixin
 from data.models import (
     Concept,
     Vocabulary,
@@ -85,8 +86,7 @@ class ScanReportFieldSerializer(serializers.ModelSerializer):
         model=ScanReportField
         fields='__all__' 
 
-
-class ScanReportValueSerializer(serializers.ModelSerializer):
+class ScanReportValueSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     value=serializers.CharField(max_length=128,allow_blank=True)
     class Meta:
         model=ScanReportValue

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,4 @@ azure-storage-queue==12.1.6
 co-connect-tools==0.2.5
 whitenoise
 gunicorn
+drf-dynamic-fields


### PR DESCRIPTION
Calum Mcdonald needs to extract only few fields from the scanreportvalues table for a specific scan report field using an API endpoint. 

This update will allow user to specify returning fields (instead of returning all fields) for the scanreportvalues of a given scan_report_field.  

The endpoint will look like this: http://localhost:8080/api/scanreportvaluesfilter/?scan_report_field=222&fields=value,frequency


