### PR TITLE
Extend gunicorn timeout to 600 (10 minutes)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,4 +9,4 @@ mkdir staticfiles
 python /api/manage.py collectstatic
 
 # Set tmp dir to be in-memory for speed. Pass logs to stdout/err as Docker will expect them there
-gunicorn --worker-tmp-dir /dev/shm --log-file=- --bind :8000 --workers 3 api.wsgi:application
+gunicorn --worker-tmp-dir /dev/shm --timeout 600 --log-file=- --bind :8000 --workers 3 api.wsgi:application


### PR DESCRIPTION
 to serve some of the longer requests which take longer than the default (30).