### PR TITLE
Shahzad - Extracting scanreport values for scan_report and scan_report_table

### DIFF
--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -79,7 +79,7 @@ class ScanReportTableSerializer(serializers.ModelSerializer):
         model=ScanReportTable
         fields='__all__'        
 
-class ScanReportFieldSerializer(serializers.ModelSerializer):
+class ScanReportFieldSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     name=serializers.CharField(max_length=64, allow_blank=True)
     description_column=serializers.CharField(max_length=256, allow_blank=True)
     class Meta:

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -30,6 +30,8 @@ routers.register(r'scanreportfieldsfilter', views.ScanReportFieldFilterViewSet,b
 
 routers.register(r'scanreportvalues', views.ScanReportValueViewSet,basename='scanreportvalues')
 routers.register(r'scanreportvaluesfilter', views.ScanReportValueFilterViewSet,basename='scanreportvaluesfilter')
+routers.register(r'scanreportvaluesfilterscanreport', views.ScanReportValuesFilterViewSetScanReport,basename='scanreportvaluesfilterscanreport')
+routers.register(r'scanreportvaluesfilterscanreporttable', views.ScanReportValuesFilterViewSetScanReportTable,basename='scanreportvaluesfilterscanreporttable')
 
 routers.register(r'scanreportconcepts', views.ScanReportConceptViewSet,basename='scanreportconcepts')
 routers.register(r'scanreportconceptsfilter', views.ScanReportConceptFilterViewSet,basename='scanreportconceptsfilter')

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -309,6 +309,24 @@ class ScanReportValueFilterViewSet(viewsets.ModelViewSet):
     filter_backends=[DjangoFilterBackend]
     filterset_fields=['scan_report_field', 'value']    
     
+class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
+    serializer_class=ScanReportValueSerializer
+    filter_backends=[DjangoFilterBackend]
+    filterset_fields=['scan_report_field__scan_report_table__scan_report']
+    def get_queryset(self):
+        qs = ScanReportValue.objects.filter(scan_report_field__scan_report_table__scan_report=
+        self.request.GET['scan_report'])
+        return qs
+
+class ScanReportValuesFilterViewSetScanReportTable(viewsets.ModelViewSet):
+    serializer_class=ScanReportValueSerializer
+    filter_backends=[DjangoFilterBackend]
+    filterset_fields=['scan_report_field__scan_report_table']
+    def get_queryset(self):
+        qs = ScanReportValue.objects.filter(scan_report_field__scan_report_table=
+        self.request.GET['scan_report_table'])
+        return qs    
+    
 @login_required
 def home(request):
     return render(request, "mapping/home.html", {})

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -307,7 +307,6 @@ class ScanReportValueFilterViewSet(viewsets.ModelViewSet):
     queryset=ScanReportValue.objects.all()
     serializer_class=ScanReportValueSerializer
     filter_backends=[DjangoFilterBackend]
-
     filterset_fields=['scan_report_field', 'value']    
     
 class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):


### PR DESCRIPTION
Addition of two new endpoints to extract all scanreportvalues for scan_report (requirement from Simon Tarr) and scan_report_table (requirement from Calum).  

1. Returning all scanreport values for a scan_report - http://localhost:8080/api/scanreportvaluesfilterscanreport/?scan_report=651
2. Returning all scanreport values for a scan_report_table - http://localhost:8080/api/scanreportvaluesfilterscanreporttable/?scan_report_table=8