### PR TITLE
Update Serializer.py to specify returning fields

### DIFF
--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -69,12 +69,12 @@ class DrugStrengthSerializer(serializers.ModelSerializer):
         model=DrugStrength
         fields='__all__'        
 
-class ScanReportSerializer(serializers.ModelSerializer):
+class ScanReportSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=ScanReport
         fields='__all__'        
 
-class ScanReportTableSerializer(serializers.ModelSerializer):
+class ScanReportTableSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=ScanReportTable
         fields='__all__'        
@@ -92,62 +92,62 @@ class ScanReportValueSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
         model=ScanReportValue
         fields='__all__'        
 
-class ScanReportConceptSerializer(serializers.ModelSerializer):
+class ScanReportConceptSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=ScanReportConcept
         fields='__all__'        
         
-class MappingSerializer(serializers.ModelSerializer):
+class MappingSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=Mapping
         fields='__all__'      
 
-class ClassificationSystemSerializer(serializers.ModelSerializer):
+class ClassificationSystemSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=ClassificationSystem
         fields='__all__'               
 
-class DataDictionarySerializer(serializers.ModelSerializer):
+class DataDictionarySerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=DataDictionary
         fields='__all__'               
 
-class DocumentSerializer(serializers.ModelSerializer):
+class DocumentSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=Document
         fields='__all__'               
 
-class DocumentFileSerializer(serializers.ModelSerializer):
+class DocumentFileSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=DocumentFile
         fields='__all__'               
 
-class DataPartnerSerializer(serializers.ModelSerializer):
+class DataPartnerSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model=DataPartner
         fields='__all__'               
 
-class OmopFieldSerializer(serializers.ModelSerializer):
+class OmopFieldSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model=OmopField
         fields='__all__'               
 
-class OmopTableSerializer(serializers.ModelSerializer):
+class OmopTableSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=OmopTable
         fields='__all__'               
 
-class StructuralMappingRuleSerializer(serializers.ModelSerializer):
+class StructuralMappingRuleSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=StructuralMappingRule
         fields='__all__' 
 
-class SourceSerializer(serializers.ModelSerializer):
+class SourceSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=Source
         fields='__all__'         
         
-class DocumentTypeSerializer(serializers.ModelSerializer):
+class DocumentTypeSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=DocumentType
         fields='__all__'                 


### PR DESCRIPTION
This update will help users to specify returning fields for every endpoint in an API (except OMOP tables, if required this can be replicated to all those endpoints that deals with OMOP tables). In case if you don't supply returning fields parameter, it will return values of all fields. 

(API endpoints without filter)
API_URL/?fields=returningfield1,returningfield2 
(e.g. http://localhost:8080/api/scanreporttables/?fields=id,name  
and http://localhost:8080/api/scanreporttables/1/?fields=id,name)

(API endpoints with filter)
API_URL/?filterfield=value1&filterfield2=value2&fields=returningfield1,returningfield2 
(e.g. http://localhost:8080/api/scanreporttablesfilter/?scan_report=1&fields=id,name,person_id)