### PR TITLE
Download SVG and PNG Image

### DIFF
--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -583,9 +583,9 @@ def download_mapping_rules(request,qs):
     return response
 
 
-def make_dag(data):
-    dot = Digraph(strict=True,format='svg')
-    dot.attr(rankdir='RL', size='8,5')
+def make_dag(data,format='svg'):
+    dot = Digraph(strict=True,format=format)
+    dot.attr(rankdir='RL')
     
     for destination_table_name,destination_tables in data.items():
         dot.node(destination_table_name,shape='box')
@@ -620,18 +620,29 @@ def make_dag(data):
                 dot.node(source_table,shape='box')
                 dot.edge(source_field_name,source_table,dir='back')
 
-    return dot.pipe().decode('utf-8')
-
+    if format == 'svg':
+        xml_str = dot.pipe().decode('utf-8')
+        return xml_str
+    else:
+        img_str = dot.pipe()
+        return img_str
 
 
 #this is here as we should move it out of coconnect.tools
-def view_mapping_rules(request,qs):
+def view_mapping_rules(request,qs,format='svg'):
     #get the rules
     output = get_mapping_rules_json(qs)
     #use make dag svg image
-    svg = make_dag(output['cdm'])
-    #return a svg response
-    response = HttpResponse(svg, content_type="image/svg+xml")
+    image = make_dag(output['cdm'],format=format)
+    
+    #return a response
+    content_type="text/plain"
+    if format == 'png':
+        #from PIL import Image
+        #img = Image.open(image)
+        #print (img)
+        content_type="image/png"
+    response = HttpResponse(image, content_type=content_type)#"image/svg+xml")
     return response
 
 

--- a/api/mapping/templates/mapping/mappingrulesscanreport_list.html
+++ b/api/mapping/templates/mapping/mappingrulesscanreport_list.html
@@ -22,6 +22,7 @@
   <button type="submit" class="btn btn-success" name='refresh_rules' id='refresh'>Refresh Rules</button>
   <button type="submit" class="btn btn-info" name='download_rules' id='get_rules'>Download Mapping JSON</button>
   <button type="button" class="btn btn-warning" name='view-rules' id='view_svg' >View Map Diagram</button>
+  <button type="button" class="btn btn-danger d-none" id='download_svg' >Download Map Diagram</button>
 
 
 <hr>
@@ -205,6 +206,31 @@
 	});
   });
 
+  $("#download_svg").click(function () {
+	var svg = $('#placeholder-svg').html();
+	$.ajax({
+	      type: "POST",
+	      url: window.location,
+	      data: {
+		    'svg_to_png': svg,
+		    'csrfmiddlewaretoken': '{{ csrf_token }}',
+	      },
+	      success: function (data) {
+		    alert(data);
+		    //var blob = new Blob([data], {type:'image/png'});
+		    //var element = document.createElement("a");
+		    //element.download = "diagram.png";
+		    //element.href = window.URL.createObjectURL(blob);
+		    //element.click();
+		    //element.remove();
+		    
+	      },
+	      error: function(XMLHttpRequest, textStatus, errorThrown){
+		    alert(errorThrown);
+	      }
+	});
+		
+  });
   
   $("#view_svg").click(function () {
 
@@ -236,14 +262,17 @@
 			    'csrfmiddlewaretoken': '{{ csrf_token }}',
 		      },
 		      success: function (data) {
-			    var data = $("svg", data);
+			    var svg = d3.select("#placeholder-svg").html(data).select("svg")
+				  .call(d3.zoom().on("zoom",function(){
+					svg.attr("transform",d3.event.transform)
+				  }));
 			    $('#spinner').addClass('d-none');
-			    $('#placeholder-svg').empty();
-			    $('#placeholder-svg').append(data);
-			    
+			    $("#download_svg").toggleClass('d-none');
+
 		      },
 		      error: function(XMLHttpRequest, textStatus, errorThrown){
 			    $('#spinner').addClass('d-none');
+			    $("#download_svg").toggleClass('d-none');
 			    $('#placeholder-svg').html(errorThrown);
 		      }
 		});
@@ -252,6 +281,7 @@
 		//otherwise if we already have the image cached
 		//toggle the display
 		$("#placeholder-svg").toggleClass('d-none');
+		$("#download_svg").toggleClass('d-none');
 	  }
 	  
     });

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -624,10 +624,14 @@ class StructuralMappingTableListView(ListView):
                                  f'Found and added rules for {nconcepts} existing concepts. However, couldnt add rules for {nbadconcepts} concepts.')
                 
             return redirect(request.path)
-
         elif request.POST.get("get_svg") is not None:
             qs = self.get_queryset()
             return view_mapping_rules(request,qs)
+        elif request.POST.get("svg_to_png") is not None:
+            svg_str = request.POST.get("svg_to_png")
+            print (svg_str)
+            test = HttpResponse("hi")
+            return test
         else:
             messages.error(request,"not working right now!")                
             return redirect(request.path)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -14,3 +14,4 @@ gunicorn
 graphviz
 drf-dynamic-fields
 django-cors-headers
+cairosvg


### PR DESCRIPTION
## The problem...
* I wanted to convert an svg image to a PNG so people could download and view

 
## Attempts
* server side convert the svg into a png and download, confusing stackoverflows on this didn't work
* post the svg html string (using jquery to get it from its div element displayed on the page) to python backend, then in python convert to png and then return png data via ajax to download... didnt work as data is not encoded correctly in base64 
* call get/post to retrieve the image again from make_dag() function, but in png form (instead format='png', instead of format='svg')... same issues with base64 encoding. Maybe writing to a temp file that could be downloaded is better
	 

## Thoughts 

* this is actually a complex problem from googling similar questions, mostly because I'm having to use AJAX to do the posting (due to spinners) 
* React probably has solutions to this, and maybe I shouldnt waste more time on this when the page will be react-ified soon