### PR TITLE
Extend ScanReportField.name and .description_column to 512 chars.

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -326,11 +326,11 @@ class ScanReportField(BaseModel):
     )
 
     name = models.CharField(
-        max_length=64,
+        max_length=512,
     )
 
     description_column = models.CharField(
-        max_length=256,
+        max_length=512,
     )
 
     type_column = models.CharField(


### PR DESCRIPTION
This requires a migration when deployed to each system.