### PR TITLE
Page max chars in env

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -118,7 +118,7 @@ def paginate(entries_to_post):
     where the maximum length of each list of dicts, under JSONification, 
     is less than max_chars
     """
-    max_chars = os.environ.get("PAGE_MAX_CHARS") if os.environ.get("PAGE_MAX_CHARS") else 10000
+    max_chars = int(os.environ.get("PAGE_MAX_CHARS")) if os.environ.get("PAGE_MAX_CHARS") else 10000
     
     paginated_entries_to_post = []
     this_page = []

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -118,8 +118,8 @@ def paginate(entries_to_post):
     where the maximum length of each list of dicts, under JSONification, 
     is less than max_chars
     """
-    max_chars = 10000
-
+    max_chars = os.environ.get("PAGE_MAX_CHARS") if os.environ.get("PAGE_MAX_CHARS") else 10000
+    
     paginated_entries_to_post = []
     this_page = []
     for entry in entries_to_post:

--- a/changelog.md
+++ b/changelog.md
@@ -12,5 +12,6 @@ Please append a line to the changelog for each change made.
 * Added REACT functionality for mapping rules table
 * Added REACT functionality for tables page
 * Pages using REACT now includes Values,Fields,Tables,Mapping Rules
+* ProcessQueue reads in PAGE_MAX_CHARS from the environment to set the max number of chars in a POST request.
 
 ## v1.0.0 was released 01/09/21


### PR DESCRIPTION
Add `PAGE_MAX_CHARS` to ProcessQueue environment to flexibly change the max chars in a POST request.