### PR TITLE
Shahzad api updates retrieve user details

### DIFF
--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -73,7 +73,7 @@ class DrugStrengthSerializer(serializers.ModelSerializer):
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = '__all__'
+        fields = ('id','username')
         
 class ScanReportSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:

--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from drf_dynamic_fields import DynamicFieldsMixin
+from django.contrib.auth.models import User
 from data.models import (
     Concept,
     Vocabulary,
@@ -67,8 +68,13 @@ class DomainSerializer(serializers.ModelSerializer):
 class DrugStrengthSerializer(serializers.ModelSerializer):
     class Meta:
         model=DrugStrength
-        fields='__all__'        
-
+        fields='__all__'  
+        
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = '__all__'
+        
 class ScanReportSerializer(DynamicFieldsMixin,serializers.ModelSerializer):
     class Meta:
         model=ScanReport

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -20,6 +20,7 @@ routers.register(r'omop/domains', views.DomainViewSet,basename='domains')
 routers.register(r'omop/drugstrengths', views.DrugStrengthViewSet,basename='drugstrengths')
 
 routers.register(r'users', views.UserViewSet,basename='users')
+routers.register(r'usersfilter', views.UserFilterViewSet,basename='users')
 
 routers.register(r'scanreports', views.ScanReportViewSet,basename='scanreports')
 

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -19,6 +19,7 @@ routers.register(r'omop/conceptsynonyms', views.ConceptSynonymViewSet,basename='
 routers.register(r'omop/domains', views.DomainViewSet,basename='domains')
 routers.register(r'omop/drugstrengths', views.DrugStrengthViewSet,basename='drugstrengths')
 
+routers.register(r'users', views.UserViewSet,basename='users')
 
 routers.register(r'scanreports', views.ScanReportViewSet,basename='scanreports')
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -26,7 +26,8 @@ from .serializers import (
     OmopFieldSerializer,
     StructuralMappingRuleSerializer,
     SourceSerializer,
-    DocumentTypeSerializer,    
+    DocumentTypeSerializer,
+    UserSerializer,
 )
 from .serializers import (
     ConceptSerializer,
@@ -174,6 +175,10 @@ class DrugStrengthViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends=[DjangoFilterBackend]
     filterset_fields=['drug_concept_id', 'ingredient_concept_id']    
 
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset=User.objects.all()
+    serializer_class=UserSerializer    
+    
 class ScanReportViewSet(viewsets.ModelViewSet):
     queryset=ScanReport.objects.all()
     serializer_class=ScanReportSerializer

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -177,7 +177,13 @@ class DrugStrengthViewSet(viewsets.ReadOnlyModelViewSet):
 
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
     queryset=User.objects.all()
+    serializer_class=UserSerializer
+
+class UserFilterViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset=User.objects.all()
     serializer_class=UserSerializer    
+    filter_backends=[DjangoFilterBackend]
+    filterset_fields={'id':['in', 'exact']}
     
 class ScanReportViewSet(viewsets.ModelViewSet):
     queryset=ScanReport.objects.all()


### PR DESCRIPTION
Samuel Adejumo is working on the scanreport page and this update will help him to extract user details for each scan report using API endppoints (as in each scan report we only store id of the user and user name and other information are usually stored in djanog user related table). 