### PR TITLE
Update models.py to store Scan Report Status

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -19,7 +19,10 @@ STATUS_CHOICES = [
 ]
 
 class Status(models.TextChoices):
-    PENDING = "PENDING", "Pending"
+    UPLOAD_IN_PROGRESS="UPINPRO","Upload in Progress"
+    UPLOAD_COMPLETE="UPCOMPL","Upload Complete"
+    UPLOAD_FAILED="UPFAILE","Upload Failed"
+    PENDING = "PENDING", "Mapping Pending"
     IN_PROGRESS_25PERCENT="INPRO25","In Progress (25%)"
     IN_PROGRESS_50PERCENT="INPRO50","In Progress (50%)"
     IN_PROGRESS_75PERCENT="INPRO75","In Progress (75%)"

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -18,6 +18,14 @@ STATUS_CHOICES = [
     (STATUS_ARCHIVED, "Archived"),
 ]
 
+class Status(models.TextChoices):
+    PENDING = "PENDING", "Pending"
+    IN_PROGRESS_25PERCENT="INPRO25","In Progress (25%)"
+    IN_PROGRESS_50PERCENT="INPRO50","In Progress (50%)"
+    IN_PROGRESS_75PERCENT="INPRO75","In Progress (75%)"
+    COMPLETE="COMPLET","Complete"
+    BLOCKED = "BLOCKED","Blocked"
+    
 class BaseModel(models.Model):
     """
     To come
@@ -272,6 +280,12 @@ class ScanReport(BaseModel):
 
     file = models.FileField()
 
+    status=models.CharField(
+        max_length=7,
+        choices=Status.choices,
+        default=Status.PENDING,        
+    )
+    
     def __str__(self):
         return str(self.id)
 


### PR DESCRIPTION
Migrations have been applied to ccnetapptestdb to reflect status field in the scan report model. 

For each value pair the first is value (INPRO25) and second is label (In Progress (25%)). 
![image](https://user-images.githubusercontent.com/53081016/136251688-bfe84b49-2379-47bc-a04d-b424cef7f076.png)

