### PR TITLE
Shahzad api endpoints count stats

### DIFF
--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -64,6 +64,10 @@ routers.register(r'sources',views.SourceViewSet,basename='sources')
 routers.register(r'documenttypes',views.DocumentTypeViewSet,basename='documenttypes')
 
 urlpatterns = [
+    path(r'api/countstats/',views.CountStats.as_view(),name='countstats'),
+    path(r'api/countstatsscanreport/',views.CountStatsScanReport.as_view(),name='countstatsscanreport'),
+    path(r'api/countstatsscanreporttable/',views.CountStatsScanReportTable.as_view(),name='countstatsscanreporttable'),
+    path(r'api/countstatsscanreporttablefield/',views.CountStatsScanReportTableField.as_view(),name='countstatsscanreporttablefield'),
     path('api/',include(routers.urls)),
     path('api_auth/',include('rest_framework.urls',namespace='rest_framework')),
     path('', views.home, name='home'),

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -10,6 +10,9 @@ from azure.storage.blob import BlobServiceClient
 
 from rest_framework import status, viewsets
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.renderers import JSONRenderer
+
 from .serializers import (
     ScanReportSerializer,
     ScanReportTableSerializer,
@@ -365,7 +368,59 @@ class ScanReportValuesFilterViewSetScanReportTable(viewsets.ModelViewSet):
         self.request.GET['scan_report_table'])
         return qs    
     
+class CountStats(APIView):          
+    renderer_classes = (JSONRenderer, )
 
+    def get(self, request, format=None):
+        scanreport_count = ScanReport.objects.count()
+        scanreporttable_count=ScanReportTable.objects.count()
+        scanreportfield_count=ScanReportField.objects.count()
+        scanReportvalue_count=ScanReportValue.objects.count()
+        content = {'scanreport_count': scanreport_count,
+        'scanreporttable_count': scanreporttable_count,
+        'scanreportfield_count': scanreportfield_count,
+        'scanreportvalue_count': scanReportvalue_count,
+        }
+        return Response(content)
+
+class CountStatsScanReport(APIView):          
+    renderer_classes = (JSONRenderer, )
+
+    def get(self, request, format=None):
+        
+        scanreporttable_count=ScanReportTable.objects.filter(scan_report=self.request.GET['scan_report']).count()        
+        scanreportfield_count=ScanReportField.objects.filter(scan_report_table__scan_report=self.request.GET['scan_report']).count()
+        scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field__scan_report_table__scan_report=self.request.GET['scan_report']).count()
+        content = {
+        'scanreporttable_count': scanreporttable_count,
+        'scanreportfield_count': scanreportfield_count,        
+        'scanreportvalue_count': scanreportvalue_count,
+        }
+        return Response(content)
+
+class CountStatsScanReportTable(APIView):          
+    renderer_classes = (JSONRenderer, )
+
+    def get(self, request, format=None):
+        
+        scanreportfield_count=ScanReportField.objects.filter(scan_report_table=self.request.GET['scan_report_table']).count()
+        scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field__scan_report_table=self.request.GET['scan_report_table']).count()
+        content = {        
+        'scanreportfield_count': scanreportfield_count,        
+        'scanreportvalue_count': scanreportvalue_count,
+        }
+        return Response(content)
+
+class CountStatsScanReportTableField(APIView):          
+    renderer_classes = (JSONRenderer, )
+
+    def get(self, request, format=None):
+               
+        scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field=self.request.GET['scan_report_field']).count()
+        content = {                
+        'scanreportvalue_count': scanreportvalue_count,
+        }
+        return Response(content)        
 # This custom ModelViewSet returns all ScanReportValues for a given ScanReport
 # It also removes all conceptIDs which == -1, leaving only those SRVs with a
 # concept_id which has been looked up with omop_helpers


### PR DESCRIPTION
This PR helps to get counts using following endpoints:
1. http://127.0.0.1:8080/api/countstats/     This endpoints returns total number of scanreports, total number of tables (across all scan reports), total number of fields (across all tables of all scan reports) and total number of values (across all fields of all tables of all scan reports), This will be useful for a dashboard page. See below a sample run on ccnetapptestdb
![image](https://user-images.githubusercontent.com/53081016/136492997-8b42966a-20af-49fb-9cfa-fbb7a20faae7.png)

2. http://127.0.0.1:8080/api/countstatsscanreport/?scan_report=56  This endpoint returns counts for a specific scan report having an id=56. The result includes (see below) total number of tables, total number of fields (across all tables for a scan report having an id=56) and total number of values (across all fields across all tables of a scan report having an id=56).
![image](https://user-images.githubusercontent.com/53081016/136493421-d0744e07-ba1c-4dd2-9783-bafa2f7afbca.png)

3.   http://127.0.0.1:8080/api/countstatsscanreporttable/?scan_report_table=300 This endpoint returns counts for a specific table having an id=300. The result includes total number of fields (for a single table having an id=300) and total number of values (across all fields of a single table having an id=300). See below an example output of an end point.
![image](https://user-images.githubusercontent.com/53081016/136493815-1dfff9a5-8d9d-4ed7-bead-0c59cc920b49.png)

4.  http://127.0.0.1:8080/api/countstatsscanreporttablefield/?scan_report_field=6776   This endpoint returns counts for a specific field in a table related to a scan report. The results includes total number of values for a specific field (e.g. having an id=6776) of a specific table of a specific scan report. See blow sample output of an endpoint. 
![image](https://user-images.githubusercontent.com/53081016/136494064-c3c234f9-7b1f-406b-9dc6-ad7042766040.png)
