### PR TITLE
Update Views.py - list of parameter for countstats

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -389,42 +389,56 @@ class CountStatsScanReport(APIView):
     renderer_classes = (JSONRenderer, )
 
     def get(self, request, format=None):
-        
-        scanreporttable_count=ScanReportTable.objects.filter(scan_report=self.request.GET['scan_report']).count()        
-        scanreportfield_count=ScanReportField.objects.filter(scan_report_table__scan_report=self.request.GET['scan_report']).count()
-        scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field__scan_report_table__scan_report=self.request.GET['scan_report']).count()
-        scanreportmappingrule_count=StructuralMappingRule.objects.filter(scan_report=self.request.GET['scan_report']).count()
-        content = {
-        'scanreporttable_count': scanreporttable_count,
-        'scanreportfield_count': scanreportfield_count,        
-        'scanreportvalue_count': scanreportvalue_count,
-        'scanreportmappingrule_count': scanreportmappingrule_count,    
-        }
-        return Response(content)
+        parameterlist=list(map(int,self.request.query_params['scan_report'].split(",")))
+        jsonrecords=[]
+        for scanreport in parameterlist:
+            scanreporttable_count=ScanReportTable.objects.filter(scan_report=scanreport).count()        
+            scanreportfield_count=ScanReportField.objects.filter(scan_report_table__scan_report=scanreport).count()
+            scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field__scan_report_table__scan_report=scanreport).count()
+            scanreportmappingrule_count=StructuralMappingRule.objects.filter(scan_report=scanreport).count()
+            
+            scanreport_content = {
+            'scanreport': scanreport,
+            'scanreporttable_count': scanreporttable_count,
+            'scanreportfield_count': scanreportfield_count,        
+            'scanreportvalue_count': scanreportvalue_count,
+            'scanreportmappingrule_count': scanreportmappingrule_count,               
+            }    
+            jsonrecords.append(scanreport_content)        
+        return Response(jsonrecords)
 
 class CountStatsScanReportTable(APIView):          
     renderer_classes = (JSONRenderer, )
 
     def get(self, request, format=None):
-        
-        scanreportfield_count=ScanReportField.objects.filter(scan_report_table=self.request.GET['scan_report_table']).count()
-        scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field__scan_report_table=self.request.GET['scan_report_table']).count()
-        content = {        
-        'scanreportfield_count': scanreportfield_count,        
-        'scanreportvalue_count': scanreportvalue_count,
-        }
-        return Response(content)
+        parameterlist=list(map(int,self.request.query_params['scan_report_table'].split(",")))
+        jsonrecords=[]
+        for scanreporttable in parameterlist:
+            scanreportfield_count=ScanReportField.objects.filter(scan_report_table=scanreporttable).count()
+            scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field__scan_report_table=scanreporttable).count()
+            
+            scanreporttable_content = {        
+            'scanreporttable': scanreporttable,
+            'scanreportfield_count': scanreportfield_count,        
+            'scanreportvalue_count': scanreportvalue_count,
+            }
+            jsonrecords.append(scanreporttable_content)
+        return Response(jsonrecords)
 
 class CountStatsScanReportTableField(APIView):          
     renderer_classes = (JSONRenderer, )
 
     def get(self, request, format=None):
-               
-        scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field=self.request.GET['scan_report_field']).count()
-        content = {                
-        'scanreportvalue_count': scanreportvalue_count,
-        }
-        return Response(content)        
+        parameterlist=list(map(int,self.request.query_params['scan_report_field'].split(",")))
+        jsonrecords=[]
+        for scanreportfield in parameterlist:
+            scanreportvalue_count=ScanReportValue.objects.filter(scan_report_field=scanreportfield).count()
+            scanreportfield_content={
+            'scanreportfield': scanreportfield,
+            'scanreportvalue_count': scanreportvalue_count
+            }
+            jsonrecords.append(scanreportfield_content)
+        return Response(jsonrecords)        
 # This custom ModelViewSet returns all ScanReportValues for a given ScanReport
 # It also removes all conceptIDs which == -1, leaving only those SRVs with a
 # concept_id which has been looked up with omop_helpers


### PR DESCRIPTION

1.  http://127.0.0.1:8080/api/countstats 
![image](https://user-images.githubusercontent.com/53081016/137507401-080d441f-6163-4996-90d3-2ecaf1acc48b.png)

2.  http://127.0.0.1:8080/api/countstatsscanreport/?scan_report=40,56,42
The first value in each JSON object represents id of scan_report (e.g. “scan_report”: 40). It is important to mention that while passing values as a parameter you can either give a single value or a list of ids with comma separated. 

![image](https://user-images.githubusercontent.com/53081016/137507502-cbfa4658-c53b-4044-8184-5af916692440.png)

3. http://127.0.0.1:8080/api/countstatsscanreporttable/?scan_report_table=284,285
It is important to mention that in each JSON object the first value (e.g. “scanreporttable”: 284) is the scan_report_table id. While using this endpoint you can either pass a single or a list of ids with comma separated. 
![image](https://user-images.githubusercontent.com/53081016/137507604-ab64053b-1cc9-44d7-b341-40d5a558b25e.png)

4. http://127.0.0.1:8080/api/countstatsscanreporttablefield/?scan_report_field=6284,6287 
It is important to mention that in each JSON object the first value (e.g. “scanreportfield”: 6284) is the scan_report_field id. While using this endpoint you can either pass a single or a list of ids with comma separated. 
 
![image](https://user-images.githubusercontent.com/53081016/137507704-ea24deb2-b2f4-4798-b9de-cd1facccbb62.png)

