### PR TITLE
Bugfix data dict

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -436,8 +436,8 @@ def main(msg: func.QueueMessage):
                         (
                             row["value"]
                             for row in data_dictionary
-                            if str(row["field_name"]) == str(name)
-                            and str(row["code"]) == str(value)
+                            if str(row["code"]) == str(value)
+                            and str(row["field_name"]) == str(name)
                             and str(row["csv_file_name"]) == str(current_table_name)
                         ),
                         None,


### PR DESCRIPTION
Add a fix so that data dictionary table name is used - previously this was not checked, and so e.g. 'Gender' in two different tables were having the same rules applied.

Also refactor a little bit for clarity.