### PR TITLE
putting in a protection for messed up rules

### DIFF
--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -223,7 +223,7 @@ def save_mapping_rules(request,scan_report_concept):
     #check whether the person_id and date events for this table are valid
     #if not, we dont want to create any rules for this concept
     if not validate_person_id_and_date(request,source_table):
-        continue
+        return False
 
     #keep a track of all rules that are being created
     #only safe them if all are successfull


### PR DESCRIPTION
@spco  this is going to fix the messed up mapping rules.

There's no reason why the rules `rule.source_field_id ` would be none. When rules are created, this should be set. This is quite a concern to me.

This is a quick lookup, reminder:
![image](https://user-images.githubusercontent.com/69473770/139240545-3816771b-d7e5-4a7b-8d5d-2a5304bb47d7.png)

Somehow these dashed lines for the mapping rules are None.. 

So this solution re-retrieves the source_field via the `ScanReportConcept` 