### PR TITLE
Save value ids and names in dictionary

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -538,7 +538,7 @@ def main(msg: func.QueueMessage):
                 values_response_content += values_content
 
             print("POST values all finished", datetime.utcnow().strftime("%H:%M:%S.%fZ"))
-
+            value_names_to_ids_dict = {str(element.get("name", None)): str(element.get("id", None)) for element in values_response_content}
             # Process conceptIDs in ScanReportValues
             # GET values where the conceptID != -1 (i.e. we've converted a concept code to conceptID in the previous code)
             print("GET posted values", datetime.utcnow().strftime("%H:%M:%S.%fZ"))

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -178,6 +178,16 @@ def get_existing_concepts(name_ids,content_type,api_url,headers):
     )
     field_names=json.loads(get_field_names.content.decode("utf-8"))
     print(field_names)
+    field_name_to_id_map ={str(element.get("name", None)): str(element.get("id", None)) for element in field_names}
+    print(field_name_to_id_map)
+    for name in name_ids.keys():
+        try:
+            link_id=field_name_to_id_map[name]
+            concept_id=field_id_to_concept_map[link_id]
+            current_id=name_ids[name]
+            print(f"Found field with id: {link_id} with exsting concept mapping: {concept_id} which matches new field id: {current_id}")
+        except:
+            continue
 
 
 def main(msg: func.QueueMessage):

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -167,6 +167,17 @@ def get_existing_concepts(name_ids,content_type,api_url,headers):
     field_id_to_concept_map ={element.get("object_id", None): str(element.get("concept", None)) for element in field_concept_ids}
 
     print("FIELD TO CONCEPT MAP DICT",field_id_to_concept_map)
+    
+    ids=list(field_id_to_concept_map.keys())
+    ids=", ".join(ids)
+    names=list(name_ids.keys())
+    names=", ".join(names)
+    get_field_names=requests.get(
+        url=f"{api_url}scanreportfieldsfilter/?id__in={ids}&name__in={names}",
+        headers=headers,
+    )
+    field_names=json.loads(get_field_names.content.decode("utf-8"))
+    print(field_names)
 
 
 def main(msg: func.QueueMessage):

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -9,6 +9,7 @@ import openpyxl
 from datetime import datetime
 import os
 import csv
+from collections import Counter
 
 from requests.models import HTTPError
 
@@ -179,6 +180,11 @@ def get_existing_concepts(name_ids,content_type,api_url,headers):
     )
     field_names=json.loads(get_field_names.content.decode("utf-8"))
     # Need to handle names not being unique before the dictionary is created
+    names=[field['name'] for field in field_names]
+    duplicates=[k for k,v in Counter(names).items() if v>1]
+    unique_names= [name for name in names if name not in duplicates]
+    print(duplicates)
+    print(unique_names)
     field_name_to_id_map ={str(element.get("name", None)): str(element.get("id", None)) for element in field_names}
 
     concepts_to_post=[]

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -227,8 +227,55 @@ def get_existing_concepts(name_ids,content_type,api_url,headers):
         concept_response_content += concept_content
 
         print("POST concepts all finished", datetime.utcnow().strftime("%H:%M:%S.%fZ"))
-            
+ 
+def get_value_concepts(values,content_type,api_url,headers):
+    names=[]
+    for value in values:
+        names.append(value['value'])
+    get_value_concept_ids= requests.get(
+            url=f"{api_url}scanreportconceptsfilter/?content_type={content_type}&fields=object_id,concept",
+            headers=headers,
+    )
+    value_concept_ids=json.loads(get_value_concept_ids.content.decode("utf-8"))
+    value_id_to_concept_map ={str(element.get("object_id", None)): str(element.get("concept", None)) for element in value_concept_ids}
 
+    # print("VALUE TO CONCEPT MAP DICT",value_id_to_concept_map)
+
+    ids=list(value_id_to_concept_map.keys())
+    
+    ids=", ".join(ids[:300])
+    
+    # names=list(values.keys())
+    print(values)
+    names=", ".join(names)
+    get_value_names=requests.get(
+        url=f"{api_url}scanreportvaluesfilter/?id__in={ids}&value__in={names}&fields=id,value",
+        headers=headers,
+    )
+    value_names=json.loads(get_value_names.content.decode("utf-8"))
+    value_name_to_id_map ={str(element.get("name", None)): str(element.get("id", None)) for element in value_names}
+    print(value_name_to_id_map)
+
+
+# def paginate_chars(entries_to_post):
+#     """
+#     This expects a list of dicts, and returns a list of lists of dicts, 
+#     where the maximum length of each list of dicts, under JSONification, 
+#     is less than max_chars
+#     """
+#     max_chars = 2000
+    
+#     paginated_entries_to_post = []
+#     chunks = []
+#     sum=0
+#     for idx,entry in enumerate(entries_to_post,start=0):
+#         sum=sum+len(entry)
+#         paginated_entries_to_post.append(entry)
+#         if sum>max_chars:
+#             index=idx
+#             chunks.append(index)
+#             sum=0
+#     return chunks
 def main(msg: func.QueueMessage):
     logging.info("Python queue trigger function processed a queue item.")
     print(datetime.utcnow().strftime("%H:%M:%S.%fZ"))

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -171,20 +171,24 @@ def get_existing_concepts(name_ids,content_type,api_url,headers):
     
     ids=list(field_id_to_concept_map.keys())
     ids=", ".join(ids)
-    names=list(name_ids.keys())
-    names=", ".join(names)
+    names_list=list(name_ids.keys())
+    names=", ".join(names_list)
 
     get_field_names=requests.get(
         url=f"{api_url}scanreportfieldsfilter/?id__in={ids}&name__in={names}",
         headers=headers,
     )
-    field_names=json.loads(get_field_names.content.decode("utf-8"))
-    # Need to handle names not being unique before the dictionary is created
-    names=[field['name'] for field in field_names]
-    duplicates=[k for k,v in Counter(names).items() if v>1]
-    unique_names= [name for name in names if name not in duplicates]
-    print(duplicates)
-    print(unique_names)
+    fields=json.loads(get_field_names.content.decode("utf-8"))
+   
+    existing_mappings=[(field['name'],field_id_to_concept_map[str(field['id'])]) for field in fields]
+
+    field_names=[]
+    for name in names_list:
+        mappings_matching_field_name = [mapping for mapping in existing_mappings if mapping[0] == name]
+        target_concept_ids = set([mapping[1] for mapping in mappings_matching_field_name])
+        if len(target_concept_ids) == 1:
+            field_names.append(name)
+
     field_name_to_id_map ={str(element.get("name", None)): str(element.get("id", None)) for element in field_names}
 
     concepts_to_post=[]

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -157,6 +157,18 @@ def process_failure(api_url, scan_report_id, headers):
     )
 
 
+def get_existing_concepts(name_ids,content_type,api_url,headers):
+    
+    get_field_concept_ids= requests.get(
+            url=f"{api_url}scanreportconceptsfilter/?content_type={content_type}",
+            headers=headers,
+    )
+    field_concept_ids=json.loads(get_field_concept_ids.content.decode("utf-8"))
+    field_id_to_concept_map ={element.get("object_id", None): str(element.get("concept", None)) for element in field_concept_ids}
+
+    print("FIELD TO CONCEPT MAP DICT",field_id_to_concept_map)
+
+
 def main(msg: func.QueueMessage):
     logging.info("Python queue trigger function processed a queue item.")
     print(datetime.utcnow().strftime("%H:%M:%S.%fZ"))
@@ -617,6 +629,7 @@ def main(msg: func.QueueMessage):
                     raise HTTPError(' '.join(['Error in value save:', str(value_response.status_code), str(put_update_json)]))
 
             print("PATCH values finished", datetime.utcnow().strftime("%H:%M:%S.%fZ"))
+            get_existing_concepts(names_to_ids_dict,15,api_url,headers)
 
     # Set the status to 'Upload Complete'
     status_complete_response = requests.patch(

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -251,7 +251,7 @@ class ScanReportConceptFilterViewSet(viewsets.ModelViewSet):
     queryset=ScanReportConcept.objects.all()
     serializer_class=ScanReportConceptSerializer  
     filter_backends=[DjangoFilterBackend]
-    filterset_fields={'concept__concept_id':['in', 'exact'],'object_id': ['in', 'exact'],'id': ['in', 'exact']}
+    filterset_fields={'concept__concept_id':['in', 'exact'],'object_id': ['in', 'exact'],'id': ['in', 'exact'],'content_type': ['in', 'exact']}
     
 class MappingViewSet(viewsets.ModelViewSet):
     queryset=Mapping.objects.all()


### PR DESCRIPTION
**What we have**
_Input_: Field names of currently uploaded scan report

**What we need**
Concept IDs for field names that have already been mapped

**Could be a helpful endpoint:**
Add a filter for content_type: 17 (values) or 15(fields)
Get all the fields with existing mappings
Get all values with existing mappings
_example_:
  Get concept for ScanReportField with ids in field_list[]
  api/scanreportconceptsfilter/object_id__in={field_list}&&content_type=15

1st Method:
1. Find the fields with the same name in the ScanReportField model
2. If fields have the same name use the id and search if a mapping exists in ScanReportConcept table(object_id=field_id)
3. If an entry is found then get the conceptID
4. Create a new ScanReportConcept entry for the new fields:
    new_concept={  ...,
                    "concept": conceptID(step 3),
                    "object_id": field_id,
                    "content_type": 15,
                }

2nd Method:

1. For all records in ScanReportConcept find the fields and their conceptIDs-> dict= field_id:concept
2. For each id (dict key) query ScanReportField table for the field names 
3. We now have field ids: names: concepts
4. Create a new ScanReportConcept entry for the new field ids