### PR TITLE
Cherry pick DD FK fix

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -461,10 +461,6 @@ class DataDictionary(BaseModel):
 
     name = models.CharField(max_length=256, blank=True, null=True)
 
-    scan_report = models.ForeignKey(
-        ScanReport, on_delete=models.CASCADE, blank=True, null=True
-    )
-
     def __str__(self):
         return str(self.id)
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -939,7 +939,6 @@ class ScanReportFormView(FormView):
                 + dt
                 + rand
                 + ".csv",
-                scan_report=scan_report,
             )
             data_dictionary.save()
             scan_report.data_dictionary = data_dictionary


### PR DESCRIPTION
Cherry pick the two commits `b555232` and `a822804` to remove `ScanReport` as a Foreign Key in the definition of `DataDictionary`.

These commits have previously been deployed to both test and prod systems.