### PR TITLE
Move datapartner to dataset

### DIFF
--- a/api/mapping/management/commands/add_datasets_to_partner.py
+++ b/api/mapping/management/commands/add_datasets_to_partner.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         data_partner_name = options.get("data_partner")
         dataset_names = options.get("datasets")
 
-        print(f"Datasets will be added to Data Partner: {data_partner_name}")
+        print(f"Datasets will be added to Data Partner: {data_partner_name}.")
 
         if dataset_names:
             # Get only the specified datasets
@@ -42,13 +42,22 @@ class Command(BaseCommand):
             orphaned_datasets = Dataset.objects.filter(data_partner=None)
 
         # Attach datasets to the data partner
-        print(f"Attaching datasets to Data Partner: {data_partner_name}")
         for dataset in orphaned_datasets:
-            data_partner, _ = DataPartner.objects.get_or_create(name=data_partner_name)
             # Use the first scan report's data partner if it exists
             if partner_from_scanreport := dataset.scan_reports.first():
+                print(
+                    f"{dataset.name}'s scan reports belong to {partner_from_scanreport.data_partner.name}."
+                )
+                print(
+                    f"Attaching {dataset.name} to Data Partner: {partner_from_scanreport.data_partner.name}."
+                )
                 dataset.data_partner = partner_from_scanreport.data_partner
             # Else, use the one specified in the command line
             else:
+                print(f"{dataset.name} is unpartnered.")
+                print(f"Attaching {dataset.name} to Data Partner: {data_partner.name}.")
+                data_partner, _ = DataPartner.objects.get_or_create(
+                    name=data_partner_name
+                )
                 dataset.data_partner = data_partner
             dataset.save()

--- a/api/mapping/management/commands/add_datasets_to_partner.py
+++ b/api/mapping/management/commands/add_datasets_to_partner.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        """Add `data_partner`, and `datasets` args."""
+        parser.add_argument(
+            "--data_partner",
+            required=False,
+            type=str,
+            default="None",
+            help='The data partner that owns the dataset(s). Default: "None"',
+        )
+        parser.add_argument(
+            "datasets",
+            default=[],
+            nargs="*",
+            help="""(Optional) The names of the dataset(s) to add to the data partner.
+            By default find all datasets with no data partner and add them to the specified
+            data partner.
+            """,
+        )
+
+    def handle(self, *args, **options):
+        pass

--- a/api/mapping/management/commands/add_datasets_to_partner.py
+++ b/api/mapping/management/commands/add_datasets_to_partner.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from mapping.models import DataPartner, Dataset, ScanReport, Project
 
 
 class Command(BaseCommand):
@@ -22,4 +23,27 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        pass
+        """Logic for finding unpartnered Datasets
+        and adding them to a Data Partner.
+        """
+
+        data_partner_name = options.get("data_partner")
+        dataset_names = options.get("datasets")
+
+        print(f"Datasets will be added to Data Partner: {data_partner_name}")
+
+        if dataset_names:
+            # Get only the specified datasets
+            print("Fetching the specified datasets...")
+            orphaned_datasets = Dataset.objects.filter(name__in=dataset_names)
+        else:
+            # Get only the datasets with no data partner
+            print("No datasets given. Fetching the unpartnered datasets...")
+            orphaned_datasets = Dataset.objects.filter(data_partner=None)
+
+        # Attach datasets to the data partner
+        print(f"Attaching datasets to Data Partner: {data_partner_name}")
+        for dataset in orphaned_datasets:
+            data_partner, _ = DataPartner.objects.get_or_create(name=data_partner_name)
+            dataset.data_partner = data_partner
+            dataset.save()

--- a/api/mapping/management/commands/add_datasets_to_partner.py
+++ b/api/mapping/management/commands/add_datasets_to_partner.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
             nargs="*",
             help="""(Optional) The names of the dataset(s) to add to the data partner.
             By default find all datasets with no data partner and add them to the specified
-            data partner or to the data partner of the dataset's first scan report.
+            data partner.
             """,
         )
 
@@ -45,10 +45,5 @@ class Command(BaseCommand):
         print(f"Attaching datasets to Data Partner: {data_partner_name}")
         for dataset in orphaned_datasets:
             data_partner, _ = DataPartner.objects.get_or_create(name=data_partner_name)
-            # Use the first scan report's data partner if it exists
-            if partner_from_scanreport := dataset.scan_reports.first():
-                dataset.data_partner = partner_from_scanreport.data_partner
-            # Else, use the one specified in the command line
-            else:
-                dataset.data_partner = data_partner
+            dataset.data_partner = data_partner
             dataset.save()

--- a/api/mapping/management/commands/add_datasets_to_partner.py
+++ b/api/mapping/management/commands/add_datasets_to_partner.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
             nargs="*",
             help="""(Optional) The names of the dataset(s) to add to the data partner.
             By default find all datasets with no data partner and add them to the specified
-            data partner.
+            data partner or to the data partner of the dataset's first scan report.
             """,
         )
 
@@ -45,5 +45,10 @@ class Command(BaseCommand):
         print(f"Attaching datasets to Data Partner: {data_partner_name}")
         for dataset in orphaned_datasets:
             data_partner, _ = DataPartner.objects.get_or_create(name=data_partner_name)
-            dataset.data_partner = data_partner
+            # Use the first scan report's data partner if it exists
+            if partner_from_scanreport := dataset.scan_reports.first():
+                dataset.data_partner = partner_from_scanreport.data_partner
+            # Else, use the one specified in the command line
+            else:
+                dataset.data_partner = data_partner
             dataset.save()

--- a/api/mapping/management/commands/unorphan_scanreports.py
+++ b/api/mapping/management/commands/unorphan_scanreports.py
@@ -1,4 +1,3 @@
-from email.policy import default
 from django.core.management.base import BaseCommand
 from mapping.models import Dataset, ScanReport, Project
 

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -151,13 +151,6 @@ class ScanReport(BaseModel):
     To come
     """
 
-    data_partner = models.ForeignKey(
-        DataPartner,
-        on_delete=models.CASCADE,
-        blank=True,
-        null=True,
-    )
-
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -151,6 +151,13 @@ class ScanReport(BaseModel):
     To come
     """
 
+    data_partner = models.ForeignKey(
+        DataPartner,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+    )
+
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -67,6 +67,7 @@ class DataPartner(BaseModel):
     """
 
     name = models.CharField(max_length=64)
+    # `datasets` field added by FK field in `Dataset`
 
     class Meta:
         verbose_name = "Data Partner"
@@ -382,6 +383,14 @@ class Dataset(BaseModel):
     """
 
     name = models.CharField(max_length=100)
+    data_partner = models.ForeignKey(
+        DataPartner,
+        on_delete=models.CASCADE,
+        related_name="datasets",
+        related_query_name="dataset",
+        # TODO: dis-allow null after all DBs are migrated
+        null=True,
+    )
     # `projects` field added by M2M field in `Project`
     # `scan_reports` field added by FK field in `ScanReport`
 


### PR DESCRIPTION
# Changes
- Add `data_partner` field to `Dataset`.
  - `NULL` is allowed for now but once the production data is migrated, this can be disallowed. Datasets must be owned by a Data Partner.
- Created `add_datasets_to_partner` management command.
  - Use to set datasets' data partners to that of the first scan report they contain, or to the one specified in the command line.