### PR TITLE
Remove data partner from scan report

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -151,13 +151,6 @@ class ScanReport(BaseModel):
     To come
     """
 
-    data_partner = models.ForeignKey(
-        DataPartner,
-        on_delete=models.CASCADE,
-        blank=True,
-        null=True,
-    )
-
     author = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -381,8 +381,6 @@ class Dataset(BaseModel):
         on_delete=models.CASCADE,
         related_name="datasets",
         related_query_name="dataset",
-        # TODO: dis-allow null after all DBs are migrated
-        null=True,
     )
     # `projects` field added by M2M field in `Project`
     # `scan_reports` field added by FK field in `ScanReport`

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 Please append a line to the changelog for each change made.
 
+## v1.5.0
+* Added Project and Dataset tables to the database.
+* Added `add_datasets_to_partner` management command.
+* Removed data_partner field from ScanReport. Added data_partner field to Dataset.
+  * __IMPORTANT!__ Steps to enact this change:
+    1. Create a migrations to add data_partner field to __Dataset__. Allow the field to be NULL.
+    2. Run the `add_datasets_to_partner` command.
+    3. Create a migration to remove the data_partner field from __ScanReport__ and remove the NULL constraint from data_partner from __Dataset__. 
+
 ## v1.4.0 was released 02/02/22
 * Mapping rules within existing Scan Reports that are (a) set to 'Mapping Complete' and (b) not 
   archived will now be reused by new Scan Reports as they are uploaded.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 Please append a line to the changelog for each change made.
 
-## v1.4-beta
+## v1.4.0 was released 02/02/22
 * Mapping rules within existing Scan Reports that are (a) set to 'Mapping Complete' and (b) not 
   archived will now be reused by new Scan Reports as they are uploaded.
 * Scan Reports and Data Dictionaries can be downloaded from the ScanReportTables page

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 Please append a line to the changelog for each change made.
 
-## v1.5.0
+## v1.5.0-beta
 * Added Project and Dataset tables to the database.
 * Added `add_datasets_to_partner` management command.
 * Removed data_partner field from ScanReport. Added data_partner field to Dataset.


### PR DESCRIPTION
# Changes
- Removed `data_partner` field from `ScanReport`
- Removed null constraint from `data_partner` field in `Dataset`