### PR TITLE
Visibility and viewers

### DIFF
--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -120,7 +120,10 @@ class ScanReportConcept(BaseModel):
     nlp_entity_type = models.CharField(max_length=64, null=True, blank=True)
 
     nlp_confidence = models.DecimalField(
-        max_digits=3, decimal_places=2, null=True, blank=True,
+        max_digits=3,
+        decimal_places=2,
+        null=True,
+        blank=True,
     )
 
     nlp_vocabulary = models.CharField(max_length=64, null=True, blank=True)
@@ -139,7 +142,9 @@ class ScanReportConcept(BaseModel):
 
     # save how the mapping rule was created
     creation_type = models.CharField(
-        max_length=1, choices=CreationType.choices, default=CreationType.Manual,
+        max_length=1,
+        choices=CreationType.choices,
+        default=CreationType.Manual,
     )
 
     def __str__(self):
@@ -152,7 +157,10 @@ class ScanReport(BaseModel):
     """
 
     author = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, blank=True, null=True,
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
     )
 
     name = models.CharField(max_length=256)
@@ -165,7 +173,9 @@ class ScanReport(BaseModel):
     file = models.FileField()
 
     status = models.CharField(
-        max_length=7, choices=Status.choices, default=Status.UPLOAD_IN_PROGRESS,
+        max_length=7,
+        choices=Status.choices,
+        default=Status.UPLOAD_IN_PROGRESS,
     )
 
     data_dictionary = models.ForeignKey(

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -392,6 +392,12 @@ class Dataset(BaseModel):
         choices=VisibilityChoices.choices,
         default=VisibilityChoices.PUBLIC,
     )
+    viewers = models.ManyToManyField(
+        settings.AUTH_USER_MODEL,
+        related_name="dataset_viewings",
+        related_query_name="dataset_viewing",
+        blank=True
+    )
     # `projects` field added by M2M field in `Project`
     # `scan_reports` field added by FK field in `ScanReport`
 

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -37,6 +37,11 @@ class CreationType(models.TextChoices):
     Reuse = "R", "Reuse"
 
 
+class VisibilityChoices(models.TextChoices):
+    PUBLIC = "PUBLIC", "Public"
+    RESTRICTED = "RESTRICTED", "Restricted"
+
+
 class BaseModel(models.Model):
     """
     To come

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -202,6 +202,13 @@ class ScanReport(BaseModel):
         default=VisibilityChoices.PUBLIC,
     )
 
+    viewers = models.ManyToManyField(
+        settings.AUTH_USER_MODEL,
+        related_name="scanreport_viewings",
+        related_query_name="scanreport_viewing",
+        blank=True
+    )
+
     def __str__(self):
         return str(self.id)
 

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -120,10 +120,7 @@ class ScanReportConcept(BaseModel):
     nlp_entity_type = models.CharField(max_length=64, null=True, blank=True)
 
     nlp_confidence = models.DecimalField(
-        max_digits=3,
-        decimal_places=2,
-        null=True,
-        blank=True,
+        max_digits=3, decimal_places=2, null=True, blank=True,
     )
 
     nlp_vocabulary = models.CharField(max_length=64, null=True, blank=True)
@@ -142,9 +139,7 @@ class ScanReportConcept(BaseModel):
 
     # save how the mapping rule was created
     creation_type = models.CharField(
-        max_length=1,
-        choices=CreationType.choices,
-        default=CreationType.Manual,
+        max_length=1, choices=CreationType.choices, default=CreationType.Manual,
     )
 
     def __str__(self):
@@ -157,10 +152,7 @@ class ScanReport(BaseModel):
     """
 
     author = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        on_delete=models.CASCADE,
-        blank=True,
-        null=True,
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, blank=True, null=True,
     )
 
     name = models.CharField(max_length=256)
@@ -173,9 +165,7 @@ class ScanReport(BaseModel):
     file = models.FileField()
 
     status = models.CharField(
-        max_length=7,
-        choices=Status.choices,
-        default=Status.UPLOAD_IN_PROGRESS,
+        max_length=7, choices=Status.choices, default=Status.UPLOAD_IN_PROGRESS,
     )
 
     data_dictionary = models.ForeignKey(
@@ -206,7 +196,7 @@ class ScanReport(BaseModel):
         settings.AUTH_USER_MODEL,
         related_name="scanreport_viewings",
         related_query_name="scanreport_viewing",
-        blank=True
+        blank=True,
     )
 
     def __str__(self):
@@ -409,7 +399,7 @@ class Dataset(BaseModel):
         settings.AUTH_USER_MODEL,
         related_name="dataset_viewings",
         related_query_name="dataset_viewing",
-        blank=True
+        blank=True,
     )
     # `projects` field added by M2M field in `Project`
     # `scan_reports` field added by FK field in `ScanReport`

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -196,6 +196,12 @@ class ScanReport(BaseModel):
         blank=True,
     )
 
+    visibility = models.CharField(
+        max_length=10,
+        choices=VisibilityChoices.choices,
+        default=VisibilityChoices.PUBLIC,
+    )
+
     def __str__(self):
         return str(self.id)
 

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -387,6 +387,11 @@ class Dataset(BaseModel):
         related_name="datasets",
         related_query_name="dataset",
     )
+    visibility = models.CharField(
+        max_length=10,
+        choices=VisibilityChoices.choices,
+        default=VisibilityChoices.PUBLIC,
+    )
     # `projects` field added by M2M field in `Project`
     # `scan_reports` field added by FK field in `ScanReport`
 

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -31,9 +31,9 @@ class CanViewDataset(permissions.BasePermission):
             self.message = "You must be granted permission to view this dataset"
             return obj.viewers.filter(id=request.user.id).exists()
         # if the visibility is public
-        # check if the user is a member in any projects the parent dataset is in
+        # check if the user is a member in any projects the dataset is in
         elif visibility == "PUBLIC":
-            # filter by projects that have dataset obj.parent_dataset
+            # filter by projects that have dataset obj.id
             # filter by projects that have user as a member
             self.message = "You are not a member of any projects for this dataset"
             return Project.objects.filter(
@@ -43,7 +43,7 @@ class CanViewDataset(permissions.BasePermission):
 
 
 class CanViewScanReport(permissions.BasePermission):
-    message = "You do not have permission to view this"
+    message = "You do not have permission to view this scan report"
 
     def has_object_permission(self, request, view, obj):
         """

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -1,4 +1,7 @@
 from rest_framework import permissions
+from .models import (
+    Project,
+)
 
 
 class CanViewProject(permissions.BasePermission):
@@ -9,3 +12,59 @@ class CanViewProject(permissions.BasePermission):
         Return `True` if the User's ID is in the Project's members.
         """
         return obj.members.filter(id=request.user.id).exists()
+
+
+class CanViewDataset(permissions.BasePermission):
+
+    message = "You do not have permission to view this dataset"
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Return `True` if, the dataset is 'public' and the User's ID is in the Project's members,
+        or, the dataset is 'restricted' and the User's ID is in a project the User is a member of.
+        """
+        visibility = obj.visibility
+
+        # if the visibility is restricted
+        # check if the user is in the viewers field
+        if visibility == "RESTRICTED":
+            self.message = "You must be granted permission to view this dataset"
+            return obj.viewers.filter(id=request.user.id).exists()
+        # if the visibility is public
+        # check if the user is a member in any projects the parent dataset is in
+        elif visibility == "PUBLIC":
+            # filter by projects that have dataset obj.parent_dataset
+            # filter by projects that have user as a member
+            self.message = "You are not a member of any projects for this dataset"
+            return Project.objects.filter(
+                datasets__id=obj.id, members__id=request.user.id
+            ).exists()
+        return False
+
+
+class CanViewScanReport(permissions.BasePermission):
+    message = "You do not have permission to view this"
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Return `True` if, the scan report is 'public' and the User's ID is in the Project's members,
+        or, the scan report is 'restricted' and the User's ID is in a project the User is a member of.
+        """
+        visibility = obj.visibility
+        # if the visibility is restricted
+        # check if the user is in the viewers field
+        if visibility == "RESTRICTED":
+            self.message = "You must be granted permission to view this scan report"
+            return obj.viewers.filter(id=request.user.id).exists()
+        # if the visibility is public
+        # check if the user is a member in any projects the parent dataset is in
+        elif visibility == "PUBLIC":
+            # get projects
+            # filter by projects that have dataset obj.parent_dataset
+            # filter by projects that have user as a member
+            self.message = "You are not a member of any projects for this scan report"
+            return Project.objects.filter(
+                datasets__id=obj.parent_dataset.id, members__id=request.user.id
+            ).exists()
+
+        return False

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -2,9 +2,9 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, force_authenticate
 from rest_framework.authtoken.models import Token
-from .permissions import CanViewProject
-from .views import ProjectRetrieveView
-from .models import Project
+from .permissions import CanViewProject, CanViewDataset, CanViewScanReport
+from .views import ProjectRetrieveView, DatasetRetrieveView, ScanReportRetrieveView
+from .models import Project, Dataset, ScanReport
 
 
 class TestCanViewProject(TestCase):
@@ -65,4 +65,300 @@ class TestCanViewProject(TestCase):
         # Assert the user not on the project doesn't have permission to see the view
         self.assertFalse(
             self.permission.has_object_permission(request, self.view, self.project)
+        )
+
+
+class TestCanViewDataset(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        # Create user who can see the Dataset whether restricted or public
+        self.restricted_user = User.objects.create(
+            username="gandalf", password="thegrey"
+        )
+        # Give them a token
+        Token.objects.create(user=self.restricted_user)
+
+        # Create user who can see the Dataset when public only
+        self.public_user = User.objects.create(username="aragorn", password="elissar")
+        # Give them a token
+        Token.objects.create(user=self.public_user)
+
+        # Create user who cannot access the Project
+        self.user_without_perm = User.objects.create(
+            username="balrog", password="youshallnotpass"
+        )
+        # Give them a token
+        Token.objects.create(user=self.user_without_perm)
+
+        # Create the project
+        self.project = Project.objects.create(name="The Fellowship of the Ring")
+        # Add the permitted users
+        self.project.members.add(self.public_user, self.restricted_user)
+        # Create the public dataset
+        self.public_dataset = Dataset.objects.create(
+            name="Hobbits of the Fellowship", visibility="PUBLIC"
+        )
+        # Create the restricted dataset
+        self.restricted_dataset = Dataset.objects.create(
+            name="Ring bearers", visibility="RESTRICTED"
+        )
+        # Add the restricted users
+        self.restricted_dataset.viewers.add(self.restricted_user)
+        # Add datasets to the project
+        self.project.datasets.add(self.restricted_dataset, self.public_dataset)
+
+        # Request factory for setting up requests
+        self.factory = APIRequestFactory()
+        # The instance of the view required for the permission class
+        self.view = DatasetRetrieveView.as_view()
+
+        # The permission class
+        self.permission = CanViewDataset()
+
+    def test_non_project_member_cannot_view(self):
+        # Make the requests for the Dataset
+        request1 = self.factory.get(f"api/datasets/{self.restricted_dataset.id}")
+        request2 = self.factory.get(f"api/datasets/{self.public_dataset.id}")
+        # Add the user to the requests; this is not automatic
+        request1.user = self.user_without_perm
+        request2.user = self.user_without_perm
+        # Authenticate the user for first request
+        force_authenticate(
+            request1,
+            user=self.user_without_perm,
+            token=self.user_without_perm.auth_token,
+        )
+        # Assert the user not on the project doesn't have permission to see the view
+        self.assertFalse(
+            self.permission.has_object_permission(
+                request1, self.view, self.restricted_dataset
+            )
+        )
+        # Authenticate the user for second request
+        force_authenticate(
+            request2,
+            user=self.user_without_perm,
+            token=self.user_without_perm.auth_token,
+        )
+        # Assert the user not on the project doesn't have permission to see the view
+        self.assertFalse(
+            self.permission.has_object_permission(
+                request2, self.view, self.public_dataset
+            )
+        )
+
+    def test_restricted_viewership(self):
+        # Make the request for the Dataset
+        request = self.factory.get(f"api/datasets/{self.restricted_dataset.id}")
+        # Add the user to the request; this is not automatic
+        request.user = self.restricted_user
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.restricted_user,
+            token=self.restricted_user.auth_token,
+        )
+        # Assert the restricted has permission to see the view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.restricted_dataset
+            )
+        )
+        # change the request user to the public user
+        request.user = self.public_user
+        # Authenticate the public user
+        force_authenticate(
+            request,
+            user=self.public_user,
+            token=self.public_user.auth_token,
+        )
+        # Assert the public user has no permission to see the view
+        self.assertFalse(
+            self.permission.has_object_permission(
+                request, self.view, self.restricted_dataset
+            )
+        )
+
+    def test_public_viewership(self):
+        # Make the request for the Dataset
+        request = self.factory.get(f"api/datasets/{self.public_dataset.id}")
+        # Add the user to the request; this is not automatic
+        request.user = self.restricted_user
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.restricted_user,
+            token=self.restricted_user.auth_token,
+        )
+        # Assert the restricted has permission to see the view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.public_dataset
+            )
+        )
+        # change the request user to the public user
+        request.user = self.public_user
+        # Authenticate the public user
+        force_authenticate(
+            request,
+            user=self.public_user,
+            token=self.public_user.auth_token,
+        )
+        # Assert the public user has permission to see the view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.public_dataset
+            )
+        )
+
+
+class TestCanViewScanReport(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        # Create user who can see the Dataset whether restricted or public
+        self.restricted_user = User.objects.create(
+            username="gandalf", password="thegrey"
+        )
+        # Give them a token
+        Token.objects.create(user=self.restricted_user)
+
+        # Create user who can see the Dataset when public only
+        self.public_user = User.objects.create(username="aragorn", password="elissar")
+        # Give them a token
+        Token.objects.create(user=self.public_user)
+
+        # Create user who cannot access the Project
+        self.user_without_perm = User.objects.create(
+            username="balrog", password="youshallnotpass"
+        )
+        # Give them a token
+        Token.objects.create(user=self.user_without_perm)
+
+        # Create the project
+        self.project = Project.objects.create(name="The Fellowship of the Ring")
+        # Add the permitted users
+        self.project.members.add(self.public_user, self.restricted_user)
+        # Create the dataset
+        self.dataset = Dataset.objects.create(
+            name="Hobbits of the Fellowship", visibility="PUBLIC"
+        )
+        # Create the public scan report
+        self.public_scan_report = ScanReport.objects.create(
+            dataset="Hobbit Heights",
+            visibility="PUBLIC",
+            parent_dataset=self.dataset,
+        )
+        # Create the restricted scan report
+        self.restricted_scan_report = ScanReport.objects.create(
+            dataset="Hobbit Diaries",
+            visibility="RESTRICTED",
+            parent_dataset=self.dataset,
+        )
+        # Add restriced user to restriced scan report
+        self.restricted_scan_report.viewers.add(self.restricted_user)
+        # Add dataset to the project
+        self.project.datasets.add(self.dataset)
+
+        # Request factory for setting up requests
+        self.factory = APIRequestFactory()
+        # The instance of the view required for the permission class
+        self.view = DatasetRetrieveView.as_view()
+
+        # The permission class
+        self.permission = CanViewScanReport()
+
+    def test_non_project_member_cannot_view(self):
+        # Make the requests for the Scan Report
+        request1 = self.factory.get(f"api/scanreports/{self.restricted_scan_report.id}")
+        request2 = self.factory.get(f"api/scanreports/{self.public_scan_report.id}")
+        # Add the user to the requests; this is not automatic
+        request1.user = self.user_without_perm
+        request2.user = self.user_without_perm
+        # Authenticate the user for first request
+        force_authenticate(
+            request1,
+            user=self.user_without_perm,
+            token=self.user_without_perm.auth_token,
+        )
+        # Assert the user not on the project doesn't have permission to see the view
+        self.assertFalse(
+            self.permission.has_object_permission(
+                request1, self.view, self.restricted_scan_report
+            )
+        )
+        # Authenticate the user for second request
+        force_authenticate(
+            request2,
+            user=self.user_without_perm,
+            token=self.user_without_perm.auth_token,
+        )
+        # Assert the user not on the project doesn't have permission to see the view
+        self.assertFalse(
+            self.permission.has_object_permission(
+                request2, self.view, self.public_scan_report
+            )
+        )
+
+    def test_restricted_viewership(self):
+        # Make the request for the Scan Report
+        request = self.factory.get(f"api/scanreports/{self.restricted_scan_report.id}")
+        # Add the user to the request; this is not automatic
+        request.user = self.restricted_user
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.restricted_user,
+            token=self.restricted_user.auth_token,
+        )
+        # Assert the restricted has permission to see the view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.restricted_scan_report
+            )
+        )
+        # change the request user to the public user
+        request.user = self.public_user
+        # Authenticate the public user
+        force_authenticate(
+            request,
+            user=self.public_user,
+            token=self.public_user.auth_token,
+        )
+        # Assert the public user has no permission to see the view
+        self.assertFalse(
+            self.permission.has_object_permission(
+                request, self.view, self.restricted_scan_report
+            )
+        )
+
+    def test_public_viewership(self):
+        # Make the request for the Scan Report
+        request = self.factory.get(f"api/scanreports/{self.public_scan_report.id}")
+        # Add the user to the request; this is not automatic
+        request.user = self.restricted_user
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.restricted_user,
+            token=self.restricted_user.auth_token,
+        )
+        # Assert the restricted has permission to see the view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.public_scan_report
+            )
+        )
+        # change the request user to the public user
+        request.user = self.public_user
+        # Authenticate the public user
+        force_authenticate(
+            request,
+            user=self.public_user,
+            token=self.public_user.auth_token,
+        )
+        # Assert the public user has permission to see the view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.public_scan_report
+            )
         )

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -40,8 +40,7 @@ routers.register(
 routers.register(r"users", views.UserViewSet, basename="users")
 routers.register(r"usersfilter", views.UserFilterViewSet, basename="users")
 
-routers.register(r"scanreports", views.ScanReportViewSet, basename="scanreports")
-
+routers.register(r"scanreports", views.ScanReportListViewSet, basename="scanreports")
 routers.register(
     r"scanreporttables", views.ScanReportTableViewSet, basename="scanreporttables"
 )
@@ -154,6 +153,16 @@ urlpatterns = [
         r"api/datasets/<int:pk>",
         views.DatasetRetrieveView.as_view(),
         name="datasets_retrieve",
+    ),
+    # path(
+    #     r"api/scanreports/",
+    #     views.ScanReportListViewSet.as_view(),
+    #     name="scanreport_list",
+    # ),
+    path(
+        r"api/scanreports/<int:pk>",
+        views.ScanReportRetrieveView.as_view(),
+        name="scanreports_retrieve",
     ),
     path(
         r"api/scanreports/<int:pk>/download/",

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -109,7 +109,11 @@ from .models import (
     ClassificationSystem,
     Dataset,
 )
-from .permissions import CanViewProject
+from .permissions import (
+    CanViewProject,
+    CanViewDataset,
+    CanViewScanReport,
+)
 from .services import download_data_dictionary_blob
 
 from .services_nlp import start_nlp_field_level
@@ -227,7 +231,7 @@ class UserFilterViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_fields = {"id": ["in", "exact"]}
 
 
-class ScanReportViewSet(viewsets.ModelViewSet):
+class ScanReportListViewSet(viewsets.ModelViewSet):
     queryset = ScanReport.objects.all()
     serializer_class = ScanReportSerializer
 
@@ -243,6 +247,19 @@ class ScanReportViewSet(viewsets.ModelViewSet):
         )
 
 
+class ScanReportRetrieveView(generics.RetrieveAPIView):
+    """
+    This view should return a single scanreport from an id
+    """
+
+    serializer_class = ScanReportSerializer
+    permission_classes = [CanViewScanReport]
+
+    def get_queryset(self):
+        qs = ScanReport.objects.filter(id=self.kwargs["pk"])
+        return qs
+
+
 class DatasetListView(generics.ListAPIView):
     """
     API view to show all datasets.
@@ -250,7 +267,6 @@ class DatasetListView(generics.ListAPIView):
 
     queryset = Dataset.objects.all()
     serializer_class = DatasetSerializer
-    # permission_classes = []
 
 
 class DatasetFilterView(generics.ListAPIView):
@@ -272,7 +288,8 @@ class DatasetRetrieveView(generics.RetrieveAPIView):
     """
 
     serializer_class = DatasetSerializer
-    # permission_classes = []
+    permission_classes = [CanViewDataset]
+
     def get_queryset(self):
         qs = Dataset.objects.filter(id=self.kwargs["pk"])
         return qs

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,15 @@ Please append a line to the changelog for each change made.
   * __IMPORTANT!__ Steps to enact this change:
     1. Create a migrations to add data_partner field to __Dataset__. Allow the field to be NULL.
     2. Run the `add_datasets_to_partner` command.
-    3. Create a migration to remove the data_partner field from __ScanReport__ and remove the NULL constraint from data_partner from __Dataset__. 
+    3. Create a migration to remove the data_partner field from __ScanReport__ and remove the NULL constraint from data_partner from __Dataset__.
+* Added visibility restrictions to Datasets and Scan Reports.
+  * "PUBLIC": anyone on the Project can view the Dataset or Scan Report.
+  * "RESTRICTED": only users in the `viewers` field of the Dataset or Scan Report can view.
+  * __IMPORTANT!__ Steps to enact this change:
+    1. Create a migration to add the `visibility` flag to __Dataset__. Set default to "PUBLIC".
+    2. Create a migration adding a `ManyToManyField` called `viewers` to __Dataset__ linking it to `settings.AUTH_USER_MODEL`.
+    3. Create a migration to add the `visibility` flag to __ScanReport__. Set default to "PUBLIC".
+    4. Create a migration adding a `ManyToManyField` called `viewers` to __ScanReport__ linking it to `settings.AUTH_USER_MODEL`.
 
 ## v1.4.0 was released 02/02/22
 * Mapping rules within existing Scan Reports that are (a) set to 'Mapping Complete' and (b) not 


### PR DESCRIPTION
# Important
Merge #382 into this branch before merging this PR.

# Changes
- Add 2 visibility choices for Scan Reports and Datasets
  - "Public" where a Scan Report or Dataset is available to users who are members of projects the Datasets and Scan Reports are in
  - "Restricted" where a Scan Report or Dataset can only be seen by those in the `viewers` fields
 - Added `visibility` field to `ScanReport` and `Dataset`
 - Added `viewers` many-to-many field to `ScanReport` and `Dataset`. Links these to the `User` model