### PR TITLE
Feature/dataset view permissions

### DIFF
--- a/api/api/react.py
+++ b/api/api/react.py
@@ -5,7 +5,7 @@ from mapping.models import Status
 
 def react(request):
     # TODO: this doesn't seem like the right to pass the token to React.
-    # It should probably be done in a cookie. But it's beyond the scope 
+    # It should probably be done in a cookie. But it's beyond the scope
     # of the current work for now.
     return {
         # "a": os.environ.get("COCONNECT_DB_AUTH_TOKEN")

--- a/api/api/react.py
+++ b/api/api/react.py
@@ -4,8 +4,12 @@ from mapping.models import Status
 
 
 def react(request):
+    # TODO: this doesn't seem like the right to pass the token to React.
+    # It should probably be done in a cookie. But it's beyond the scope 
+    # of the current work for now.
     return {
-        "a": os.environ.get("COCONNECT_DB_AUTH_TOKEN"),
+        # "a": os.environ.get("COCONNECT_DB_AUTH_TOKEN")
+        "a": getattr(request.user, "auth_token", ""),
         "u": os.environ.get("CCOM_APP_URL"),
         "status": [{"id": id, "label": label} for id, label in Status.choices],
     }

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -1,3 +1,4 @@
+import os
 from rest_framework import permissions
 from .models import (
     Project,
@@ -20,11 +21,16 @@ class CanViewDataset(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         """
-        Return `True` if, the dataset is 'public' and the User's ID is in the Project's members,
-        or, the dataset is 'restricted' and the User's ID is in a project the User is a member of.
+        Return `True` in any of the following cases: 
+            - the User is the `AZ_FUNCTION_USER`
+            - the dataset is 'RESTRICTED' and the User's ID is in a project the User is a member of.
+            - the dataset is 'PUBLIC' and the User's ID is in the Project's members,
         """
         visibility = obj.visibility
 
+        # if the User is the `AZ_FUNCTION_USER` grant permission
+        if request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return True
         # if the visibility is restricted
         # check if the user is in the viewers field
         if visibility == "RESTRICTED":

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -23,8 +23,9 @@ class CanViewDataset(permissions.BasePermission):
         """
         Return `True` in any of the following cases:
             - the User is the `AZ_FUNCTION_USER`
-            - the dataset is 'RESTRICTED' and the User's ID is in a project the User is a member of.
-            - the dataset is 'PUBLIC' and the User's ID is in the Project's members,
+            - the Dataset is 'RESTRICTED' and the User is a Dataset viewer
+            - the Dataset is 'PUBLIC' and the User is a member of a Project
+            that the Dataset is in.
         """
         visibility = obj.visibility
 

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -21,7 +21,7 @@ class CanViewDataset(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         """
-        Return `True` in any of the following cases: 
+        Return `True` in any of the following cases:
             - the User is the `AZ_FUNCTION_USER`
             - the dataset is 'RESTRICTED' and the User's ID is in a project the User is a member of.
             - the dataset is 'PUBLIC' and the User's ID is in the Project's members,

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -262,7 +262,7 @@ class TestCanViewScanReport(TestCase):
         # Request factory for setting up requests
         self.factory = APIRequestFactory()
         # The instance of the view required for the permission class
-        self.view = DatasetRetrieveView.as_view()
+        self.view = ScanReportRetrieveView.as_view()
 
         # The permission class
         self.permission = CanViewScanReport()

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -248,6 +248,7 @@ class TestCanViewDataset(TestCase):
             )
         )
 
+
 class TestCanViewScanReport(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -64,17 +64,19 @@ class TestDatasetListView(TestCase):
         )
         # Get the response data
         response_data = self.view(request).data
+        expected_objs = [
+            self.public_dataset1.id,
+            self.public_dataset2.id,
+            self.restricted_dataset.id,
+        ]
 
         # Assert user1 can only public_dataset1, public_dataset2
         # and restricted_dataset
+        self.assertEqual(len(response_data), len(expected_objs))
         for obj in response_data:
             self.assertIn(
                 obj.get("id"),
-                [
-                    self.public_dataset1.id,
-                    self.public_dataset2.id,
-                    self.restricted_dataset.id,
-                ],
+                expected_objs,
             )
 
         # Assert user1 can't see public_dataset3
@@ -91,12 +93,14 @@ class TestDatasetListView(TestCase):
         )
         # Get the response
         response_data = self.view(request).data
+        expected_objs = [self.public_dataset1.id, self.public_dataset2.id]
 
         # Assert user2 can only public_dataset1 and public_dataset2
+        self.assertEqual(len(response_data), len(expected_objs))
         for obj in response_data:
             self.assertIn(
                 obj.get("id"),
-                [self.public_dataset1.id, self.public_dataset2.id],
+                expected_objs,
             )
 
         # Assert user2 can't see public_dataset3

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -157,5 +157,7 @@ class TestDatasetListView(TestCase):
         # Get the response
         response_data = self.view(request).data
         # Assert az_user can see all datasets
-        for obj in response_data:
-            self.assertTrue(Dataset.objects.filter(id=obj.get("id")).exists())
+        self.assertEqual(
+            len(response_data),
+            Dataset.objects.all().count()
+        )

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -64,6 +64,7 @@ class TestDatasetListView(TestCase):
         )
         # Get the response data
         response_data = self.view(request).data
+        response_data = [obj.get("id") for obj in response_data]
         expected_objs = [
             self.public_dataset1.id,
             self.public_dataset2.id,
@@ -72,16 +73,11 @@ class TestDatasetListView(TestCase):
 
         # Assert user1 can only public_dataset1, public_dataset2
         # and restricted_dataset
-        self.assertEqual(len(response_data), len(expected_objs))
-        for obj in response_data:
-            self.assertIn(
-                obj.get("id"),
-                expected_objs,
-            )
+        self.assertEqual(sorted(response_data), sorted(expected_objs))
 
         # Assert user1 can't see public_dataset3
         for obj in response_data:
-            self.assertNotEqual(obj.get("id"), self.public_dataset3.id)
+            self.assertNotEqual(obj, self.public_dataset3.id)
 
         # Add user2 to the request; this is not automatic
         request.user = self.user2
@@ -93,19 +89,15 @@ class TestDatasetListView(TestCase):
         )
         # Get the response
         response_data = self.view(request).data
+        response_data = [obj.get("id") for obj in response_data]
         expected_objs = [self.public_dataset1.id, self.public_dataset2.id]
 
         # Assert user2 can only public_dataset1 and public_dataset2
-        self.assertEqual(len(response_data), len(expected_objs))
-        for obj in response_data:
-            self.assertIn(
-                obj.get("id"),
-                expected_objs,
-            )
+        self.assertEqual(sorted(response_data), sorted(expected_objs))
 
         # Assert user2 can't see public_dataset3
         for obj in response_data:
-            self.assertNotEqual(obj.get("id"), self.public_dataset3.id)
+            self.assertNotEqual(obj, self.public_dataset3.id)
 
     def test_dataset_filtering(self):
         # Make the request for the public_dataset1
@@ -122,10 +114,11 @@ class TestDatasetListView(TestCase):
         )
         # Get the response
         response_data = self.view(request).data
+        response_data = [obj.get("id") for obj in response_data]
 
         # Assert only got public_dataset1
         self.assertEqual(len(response_data), 1)
-        self.assertEqual(response_data[0].get("id"), self.public_dataset1.id)
+        self.assertEqual(response_data[0], self.public_dataset1.id)
 
         # Make the request for the public_dataset3
         request = self.factory.get(

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -158,6 +158,4 @@ class TestDatasetListView(TestCase):
         response_data = self.view(request).data
         # Assert az_user can see all datasets
         for obj in response_data:
-            self.assertTrue(
-                Dataset.objects.filter(id=obj.get("id")).exists()
-            )
+            self.assertTrue(Dataset.objects.filter(id=obj.get("id")).exists())

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -56,17 +56,17 @@ class TestDatasetListView(TestCase):
         self.view = DatasetListView.as_view()
 
     def test_dataset_returns(self):
-        # Make the request for the Dataset
+        # Make the request for Datasets
         request = self.factory.get(f"api/datasets/")
         # Add user1 to the request; this is not automatic
         request.user = self.user1
-        # Authenticate the restricted user
+        # Authenticate the user1
         force_authenticate(
             request,
             user=self.user1,
             token=self.user1.auth_token,
         )
-        # Get the response
+        # Get the response data
         response_data = self.view(request).data
 
         # Assert user1 can only public_dataset1, public_dataset2
@@ -87,7 +87,7 @@ class TestDatasetListView(TestCase):
 
         # Add user2 to the request; this is not automatic
         request.user = self.user2
-        # Authenticate the restricted user
+        # Authenticate the user2
         force_authenticate(
             request,
             user=self.user2,
@@ -108,11 +108,11 @@ class TestDatasetListView(TestCase):
             self.assertNotEqual(obj.get("id"), self.public_dataset3.id)
 
     def test_dataset_filtering(self):
-        # Make the request for the Dataset
+        # Make the request for the public_dataset1
         request = self.factory.get(f"api/datasets/", {"id__in": self.public_dataset1.id})
         # Add user1 to the request; this is not automatic
         request.user = self.user1
-        # Authenticate the restricted user
+        # Authenticate user1
         force_authenticate(
             request,
             user=self.user1,
@@ -129,7 +129,7 @@ class TestDatasetListView(TestCase):
         request = self.factory.get(f"api/datasets/", {"id__in": self.public_dataset3.id})
         # Add user1 to the request; this is not automatic
         request.user = self.user1
-        # Authenticate the restricted user
+        # Authenticate user1
         force_authenticate(
             request,
             user=self.user1,

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -161,7 +161,4 @@ class TestDatasetListView(TestCase):
         # Get the response
         response_data = self.view(request).data
         # Assert az_user can see all datasets
-        self.assertEqual(
-            len(response_data),
-            Dataset.objects.all().count()
-        )
+        self.assertEqual(len(response_data), Dataset.objects.all().count())

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -106,3 +106,37 @@ class TestDatasetListView(TestCase):
         # Assert user2 can't see public_dataset3
         for obj in response_data:
             self.assertNotEqual(obj.get("id"), self.public_dataset3.id)
+
+    def test_dataset_filtering(self):
+        # Make the request for the Dataset
+        request = self.factory.get(f"api/datasets/", {"id__in": self.public_dataset1.id})
+        # Add user1 to the request; this is not automatic
+        request.user = self.user1
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.user1,
+            token=self.user1.auth_token,
+        )
+        # Get the response
+        response_data = self.view(request).data
+
+        # Assert only got public_dataset1
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0].get("id"), self.public_dataset1.id)
+
+        # Make the request for the public_dataset3
+        request = self.factory.get(f"api/datasets/", {"id__in": self.public_dataset3.id})
+        # Add user1 to the request; this is not automatic
+        request.user = self.user1
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.user1,
+            token=self.user1.auth_token,
+        )
+        # Get the response
+        response_data = self.view(request).data
+
+        # Assert response is empty
+        self.assertEqual(response_data, [])

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -18,20 +18,16 @@ class TestDatasetListView(TestCase):
 
         # Set up datasets
         self.public_dataset1 = Dataset.objects.create(
-            name="Places in Middle Earth",
-            visibility="PUBLIC"
+            name="Places in Middle Earth", visibility="PUBLIC"
         )
         self.public_dataset2 = Dataset.objects.create(
-            name="Places in Valinor",
-            visibility="PUBLIC"
+            name="Places in Valinor", visibility="PUBLIC"
         )
         self.public_dataset3 = Dataset.objects.create(
-            name="The Rings of Power",
-            visibility="PUBLIC"
+            name="The Rings of Power", visibility="PUBLIC"
         )
         self.restricted_dataset = Dataset.objects.create(
-            name="Fellowship Members",
-            visibility="RESTRICTED"
+            name="Fellowship Members", visibility="RESTRICTED"
         )
         self.restricted_dataset.viewers.add(self.user1)
 
@@ -41,7 +37,7 @@ class TestDatasetListView(TestCase):
         self.project1.datasets.add(
             self.public_dataset1,
             self.public_dataset2,
-            self.restricted_dataset  # user2 can't see
+            self.restricted_dataset,  # user2 can't see
         )
         self.project2 = Project.objects.create(name="The Two Towers")
         self.project2.members.add(self.user1)
@@ -77,7 +73,7 @@ class TestDatasetListView(TestCase):
                 [
                     self.public_dataset1.id,
                     self.public_dataset2.id,
-                    self.restricted_dataset.id
+                    self.restricted_dataset.id,
                 ],
             )
 
@@ -109,7 +105,9 @@ class TestDatasetListView(TestCase):
 
     def test_dataset_filtering(self):
         # Make the request for the public_dataset1
-        request = self.factory.get(f"api/datasets/", {"id__in": self.public_dataset1.id})
+        request = self.factory.get(
+            f"api/datasets/", {"id__in": self.public_dataset1.id}
+        )
         # Add user1 to the request; this is not automatic
         request.user = self.user1
         # Authenticate user1
@@ -126,7 +124,9 @@ class TestDatasetListView(TestCase):
         self.assertEqual(response_data[0].get("id"), self.public_dataset1.id)
 
         # Make the request for the public_dataset3
-        request = self.factory.get(f"api/datasets/", {"id__in": self.public_dataset3.id})
+        request = self.factory.get(
+            f"api/datasets/", {"id__in": self.public_dataset3.id}
+        )
         # Add user1 to the request; this is not automatic
         request.user = self.user1
         # Authenticate user1

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -1,0 +1,108 @@
+from urllib import response
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.authtoken.models import Token
+from .views import DatasetListView
+from .models import Project, Dataset
+
+
+class TestDatasetListView(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        # Set up users
+        self.user1 = User.objects.create(username="gandalf", password="iwjfijweifje")
+        Token.objects.create(user=self.user1)
+        self.user2 = User.objects.create(username="aragorn", password="ooieriofiejr")
+        Token.objects.create(user=self.user2)
+
+        # Set up datasets
+        self.public_dataset1 = Dataset.objects.create(
+            name="Places in Middle Earth",
+            visibility="PUBLIC"
+        )
+        self.public_dataset2 = Dataset.objects.create(
+            name="Places in Valinor",
+            visibility="PUBLIC"
+        )
+        self.public_dataset3 = Dataset.objects.create(
+            name="The Rings of Power",
+            visibility="PUBLIC"
+        )
+        self.restricted_dataset = Dataset.objects.create(
+            name="Fellowship Members",
+            visibility="RESTRICTED"
+        )
+        self.restricted_dataset.viewers.add(self.user1)
+
+        # Set up projects
+        self.project1 = Project.objects.create(name="The Fellowship of the Ring")
+        self.project1.members.add(self.user1, self.user2)
+        self.project1.datasets.add(
+            self.public_dataset1,
+            self.public_dataset2,
+            self.restricted_dataset  # user2 can't see
+        )
+        self.project2 = Project.objects.create(name="The Two Towers")
+        self.project2.members.add(self.user1)
+        self.project2.datasets.add(self.restricted_dataset)
+        self.project3 = Project.objects.create(name="The Return of the King")
+        self.project3.datasets.add(self.public_dataset3)
+
+        # Request factory for setting up requests
+        self.factory = APIRequestFactory()
+
+        # The view for the tests
+        self.view = DatasetListView.as_view()
+
+    def test_dataset_returns(self):
+        # Make the request for the Dataset
+        request = self.factory.get(f"api/datasets/")
+        # Add user1 to the request; this is not automatic
+        request.user = self.user1
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.user1,
+            token=self.user1.auth_token,
+        )
+        # Get the response
+        response_data = self.view(request).data
+
+        # Assert user1 can only public_dataset1, public_dataset2
+        # and restricted_dataset
+        for obj in response_data:
+            self.assertIn(
+                obj.get("id"),
+                [
+                    self.public_dataset1.id,
+                    self.public_dataset2.id,
+                    self.restricted_dataset.id
+                ],
+            )
+
+        # Assert user1 can't see public_dataset3
+        for obj in response_data:
+            self.assertNotEqual(obj.get("id"), self.public_dataset3.id)
+
+        # Add user2 to the request; this is not automatic
+        request.user = self.user2
+        # Authenticate the restricted user
+        force_authenticate(
+            request,
+            user=self.user2,
+            token=self.user2.auth_token,
+        )
+        # Get the response
+        response_data = self.view(request).data
+
+        # Assert user2 can only public_dataset1 and public_dataset2
+        for obj in response_data:
+            self.assertIn(
+                obj.get("id"),
+                [self.public_dataset1.id, self.public_dataset2.id],
+            )
+
+        # Assert user2 can't see public_dataset3
+        for obj in response_data:
+            self.assertNotEqual(obj.get("id"), self.public_dataset3.id)

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -145,11 +145,6 @@ urlpatterns = [
         name="dataset_list",
     ),
     path(
-        r"api/datasetsfilter/",
-        views.DatasetFilterView.as_view(),
-        name="dataset_filter",
-    ),
-    path(
         r"api/datasets/<int:pk>",
         views.DatasetRetrieveView.as_view(),
         name="datasets_retrieve",

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -140,14 +140,9 @@ urlpatterns = [
         name="countstatsscanreporttablefield",
     ),
     path(
-        r"api/datasets/",
+        r"api/datasets",
         views.DatasetListView.as_view(),
         name="dataset_list",
-    ),
-    path(
-        r"api/datasetsfilter/",
-        views.DatasetFilterView.as_view(),
-        name="dataset_filter",
     ),
     path(
         r"api/datasets/<int:pk>",

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -140,9 +140,14 @@ urlpatterns = [
         name="countstatsscanreporttablefield",
     ),
     path(
-        r"api/datasets",
+        r"api/datasets/",
         views.DatasetListView.as_view(),
         name="dataset_list",
+    ),
+    path(
+        r"api/datasetsfilter/",
+        views.DatasetFilterView.as_view(),
+        name="dataset_filter",
     ),
     path(
         r"api/datasets/<int:pk>",

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -289,19 +289,6 @@ class DatasetListView(generics.ListAPIView):
         )
 
 
-class DatasetFilterView(generics.ListAPIView):
-    """
-    API view to filter datasets by list of id's.
-    """
-
-    queryset = Dataset.objects.all()
-    serializer_class = DatasetSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = {
-        "id": ["in"],
-    }
-
-
 class DatasetRetrieveView(generics.RetrieveAPIView):
     """
     This view should return a single dataset from an id

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -291,7 +291,7 @@ class DatasetListView(generics.ListAPIView):
                 viewers=self.request.user.id,
                 visibility="RESTRICTED",
             )
-        )
+        ).distinct()
 
 
 class DatasetRetrieveView(generics.RetrieveAPIView):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -266,6 +266,10 @@ class DatasetListView(generics.ListAPIView):
     """
 
     serializer_class = DatasetSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {
+        "id": ["in"],
+    }
 
     def get_queryset(self):
         """

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -279,7 +279,7 @@ class DatasetListView(generics.ListAPIView):
         which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
         """
         if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
-            return Dataset.objects.all()
+            return Dataset.objects.all().distinct()
 
         return Dataset.objects.filter(
             Q(

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -262,33 +262,24 @@ class ScanReportRetrieveView(generics.RetrieveAPIView):
 
 class DatasetListView(generics.ListAPIView):
     """
-    API showing a list of Datasets associated to a Project.
-    The GET request requires a `project` param with the ID
-    of a specific project. The view returns 400 Bad Request
-    if `project` is not specified. 
+    API view to show all datasets.
     """
 
+    queryset = Dataset.objects.all()
+    serializer_class = DatasetSerializer
+
+
+class DatasetFilterView(generics.ListAPIView):
+    """
+    API view to filter datasets by list of id's.
+    """
+
+    queryset = Dataset.objects.all()
     serializer_class = DatasetSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
-        "id": ["in", "exact"],
+        "id": ["in"],
     }
-
-    def get_queryset(self):
-        project_id = self.request.query_params.get("project")
-        return Dataset.objects.filter(
-            project__id=int(project_id),
-            project__members=self.request.user.id,
-        )
-
-    def get(self, request, *args, **kwargs):
-        if request.query_params.get("project"):
-            return super().get(request, *args, **kwargs)
-        else:
-            return Response(
-                data={"detail": "You must specify a project ID in the GET params."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
 
 
 class DatasetRetrieveView(generics.RetrieveAPIView):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -262,7 +262,7 @@ class ScanReportRetrieveView(generics.RetrieveAPIView):
 
 class DatasetListView(generics.ListAPIView):
     """
-    API view to show all datasets.
+    API view to show all datasets a user has access to.
     """
 
     serializer_class = DatasetSerializer
@@ -273,9 +273,14 @@ class DatasetListView(generics.ListAPIView):
 
     def get_queryset(self):
         """
-        Return only the Datasets which are on projects a user is a member,
+        If the User is the `AZ_FUNCTION_USER`, return all Datasets.
+
+        Else, return only the Datasets which are on projects a user is a member,
         which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
         """
+        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return Dataset.objects.all()
+        
         return Dataset.objects.filter(
             Q(
                 project__members=self.request.user.id,

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -266,10 +266,6 @@ class DatasetListView(generics.ListAPIView):
     """
 
     serializer_class = DatasetSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = {
-        "id": ["in"],
-    }
 
     def get_queryset(self):
         """

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -262,24 +262,33 @@ class ScanReportRetrieveView(generics.RetrieveAPIView):
 
 class DatasetListView(generics.ListAPIView):
     """
-    API view to show all datasets.
+    API showing a list of Datasets associated to a Project.
+    The GET request requires a `project` param with the ID
+    of a specific project. The view returns 400 Bad Request
+    if `project` is not specified. 
     """
 
-    queryset = Dataset.objects.all()
-    serializer_class = DatasetSerializer
-
-
-class DatasetFilterView(generics.ListAPIView):
-    """
-    API view to filter datasets by list of id's.
-    """
-
-    queryset = Dataset.objects.all()
     serializer_class = DatasetSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
-        "id": ["in"],
+        "id": ["in", "exact"],
     }
+
+    def get_queryset(self):
+        project_id = self.request.query_params.get("project")
+        return Dataset.objects.filter(
+            project__id=int(project_id),
+            project__members=self.request.user.id,
+        )
+
+    def get(self, request, *args, **kwargs):
+        if request.query_params.get("project"):
+            return super().get(request, *args, **kwargs)
+        else:
+            return Response(
+                data={"detail": "You must specify a project ID in the GET params."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
 
 class DatasetRetrieveView(generics.RetrieveAPIView):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -283,6 +283,7 @@ class DatasetListView(generics.ListAPIView):
         restricted = Dataset.objects.filter(
             project__members=self.request.user.id,
             viewers=self.request.user.id,
+            visibility="RESTRICTED"
         )
         return public.union(restricted)
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -276,16 +276,17 @@ class DatasetListView(generics.ListAPIView):
         Return only the Datasets which are on projects a user is a member,
         which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
         """
-        public = Dataset.objects.filter(
-            project__members=self.request.user.id,
-            visibility="PUBLIC",
+        return Dataset.objects.filter(
+            Q(
+                project__members=self.request.user.id,
+                visibility="PUBLIC",
+            )
+            | Q(
+                project__members=self.request.user.id,
+                viewers=self.request.user.id,
+                visibility="RESTRICTED",
+            )
         )
-        restricted = Dataset.objects.filter(
-            project__members=self.request.user.id,
-            viewers=self.request.user.id,
-            visibility="RESTRICTED"
-        )
-        return public.union(restricted)
 
 
 class DatasetFilterView(generics.ListAPIView):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -280,7 +280,7 @@ class DatasetListView(generics.ListAPIView):
         """
         if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
             return Dataset.objects.all()
-        
+
         return Dataset.objects.filter(
             Q(
                 project__members=self.request.user.id,

--- a/react-client-app/src/components/Home.jsx
+++ b/react-client-app/src/components/Home.jsx
@@ -108,7 +108,7 @@ const Home = () => {
         const datasetIds = chunkIds(Object.keys(datasetObject))
         const datasetPromises = []
         for (let i = 0; i < datasetIds.length; i++) {
-            datasetPromises.push(useGet(`/datasetsfilter/?id__in=${datasetIds[i].join()}`))
+            datasetPromises.push(useGet(`/datasets/?id__in=${datasetIds[i].join()}`))
         }
         let datasets = await Promise.all(datasetPromises)
         datasets = [].concat.apply([], datasets)

--- a/react-client-app/src/components/ScanReportTbl.jsx
+++ b/react-client-app/src/components/ScanReportTbl.jsx
@@ -51,7 +51,7 @@ const ScanReportTbl = (props) => {
             authorPromises.push(useGet(`/usersfilter/?id__in=${authorIds[i].join()}`));
         }
         for (let i = 0; i < datasetIds.length; i++) {
-            datasetPromises.push(useGet(`/datasetsfilter/?id__in=${datasetIds[i].join()}`));
+            datasetPromises.push(useGet(`/datasets/?id__in=${datasetIds[i].join()}`));
         }
         const promises = await Promise.all([Promise.all(authorPromises), Promise.all(datasetPromises)]);
         const authors = [].concat.apply([], promises[0]);


### PR DESCRIPTION
# Changes
- Overridden `get_queryset` in `views.DatasetListView`
  - it will only return Datasets that are public or restricted Datasets that a suer is a viewer of
  - These will only be Datasets from Projects a user is a member of
- Added filter backend to `views.DatasetListView` from `views.DatasetFilterView`
- Removed `views.DatasetFilterView` and associated URL
- Replaced filter view URL calls with calls to `views.DatasetListView`
- Added unit tests for `views.DatasetListView`
- Added temporary fix so React code gets the right user token