### PR TITLE
Feature/scan report permissions

### DIFF
--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -54,10 +54,17 @@ class CanViewScanReport(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         """
-        Return `True` if, the scan report is 'public' and the User's ID is in the Project's members,
-        or, the scan report is 'restricted' and the User's ID is in a project the User is a member of.
+        Return `True` in any of the following cases:
+            - the User is the `AZ_FUNCTION_USER`
+            - the ScanReport is 'RESTRICTED' and the User is a ScanReport viewer
+            - the ScanReport is 'PUBLIC' and the User is a member of a Project
+            that the ScanReport's parent Dataset is in.
         """
         visibility = obj.visibility
+        
+        # if the User is the `AZ_FUNCTION_USER` grant permission
+        if request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return True
         # if the visibility is restricted
         # check if the user is in the viewers field
         if visibility == "RESTRICTED":

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -61,7 +61,7 @@ class CanViewScanReport(permissions.BasePermission):
             that the ScanReport's parent Dataset is in.
         """
         visibility = obj.visibility
-        
+
         # if the User is the `AZ_FUNCTION_USER` grant permission
         if request.user.username == os.getenv("AZ_FUNCTION_USER"):
             return True

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -399,3 +399,39 @@ class TestCanViewScanReport(TestCase):
                 request, self.view, self.public_scan_report
             )
         )
+
+    def test_az_function_user_perm(self):
+        User = get_user_model()
+        az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
+        # Make the request for the Scan Report
+        request = self.factory.get(f"api/scanreports/{self.restricted_scan_report.id}")
+        # Add the user to the request; this is not automatic
+        request.user = az_user
+        # Authenticate az_user
+        force_authenticate(
+            request,
+            user=az_user,
+            token=az_user.auth_token,
+        )
+        # Assert az_user has permission on restricted view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.restricted_scan_report
+            )
+        )
+        # Make the request for the Scan Report
+        request = self.factory.get(f"api/scanreports/{self.public_scan_report.id}")
+        # Add the user to the request; this is not automatic
+        request.user = az_user
+        # Authenticate az_user
+        force_authenticate(
+            request,
+            user=az_user,
+            token=az_user.auth_token,
+        )
+        # Assert az_user has permission on public view
+        self.assertTrue(
+            self.permission.has_object_permission(
+                request, self.view, self.public_scan_report
+            )
+        )

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -183,7 +183,7 @@ class TestScanScanReportListViewset(TestCase):
         self.public_scanreport = ScanReport.objects.create(
             dataset="The Mines of Moria",
             visibility=VisibilityChoices.PUBLIC,
-            parent_dataset=self.public_dataset
+            parent_dataset=self.public_dataset,
         )
         self.restricted_scanreport1 = ScanReport.objects.create(
             dataset="The Rings of Power",

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -224,18 +224,16 @@ class TestScanScanReportListViewset(TestCase):
         )
         # Get the response data
         response_data = self.view(request).data
+        response_data = [obj.get("id") for obj in response_data]
+        expected_objs = [
+            self.public_scanreport.id,
+            self.restricted_scanreport1.id,
+            self.restricted_scanreport2.id,
+        ]
 
         # Assert user1 can see all scan reports
         # and restricted_dataset
-        for obj in response_data:
-            self.assertIn(
-                obj.get("id"),
-                [
-                    self.public_scanreport.id,
-                    self.restricted_scanreport1.id,
-                    self.restricted_scanreport2.id,
-                ],
-            )
+        self.assertEqual(sorted(response_data), sorted(expected_objs))
 
         # Add user2 to the request; this is not automatic
         request.user = self.user2
@@ -247,17 +245,15 @@ class TestScanScanReportListViewset(TestCase):
         )
         # Get the response
         response_data = self.view(request).data
+        response_data = [obj.get("id") for obj in response_data]
+        expected_objs = [self.public_scanreport.id, self.restricted_scanreport1.id]
 
         # Assert user2 can see public_scanreport and restricted_scanreport1
-        for obj in response_data:
-            self.assertIn(
-                obj.get("id"),
-                [self.public_scanreport.id, self.restricted_scanreport1.id],
-            )
+        self.assertEqual(sorted(response_data), sorted(expected_objs))
 
         # Assert user2 can't see restricted_scanreport2
         for obj in response_data:
-            self.assertNotEqual(obj.get("id"), self.restricted_scanreport2.id)
+            self.assertNotEqual(obj, self.restricted_scanreport2.id)
 
     def test_az_function_user_perm(self):
         User = get_user_model()
@@ -275,5 +271,4 @@ class TestScanScanReportListViewset(TestCase):
         # Get the response
         response_data = self.view(request).data
         # Assert az_user can see all scan reports
-        obj_ids = [obj.get("id") for obj in response_data]
-        self.assertTrue(ScanReport.objects.filter(id__in=obj_ids).exists())
+        self.assertEqual(len(response_data), ScanReport.objects.all().count())

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -244,7 +244,7 @@ class ScanReportListViewSet(viewsets.ModelViewSet):
         """
         if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
             return ScanReport.objects.all()
-        
+
         return ScanReport.objects.filter(
             Q(
                 parent_dataset__project__members=self.request.user.id,

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -108,6 +108,7 @@ from .models import (
     ScanReportConcept,
     ClassificationSystem,
     Dataset,
+    VisibilityChoices,
 )
 from .permissions import (
     CanViewProject,
@@ -247,12 +248,21 @@ class ScanReportListViewSet(viewsets.ModelViewSet):
         return ScanReport.objects.filter(
             Q(
                 parent_dataset__project__members=self.request.user.id,
-                visibility="PUBLIC",
+                parent_dataset__visibility=VisibilityChoices.PUBLIC,
+                visibility=VisibilityChoices.PUBLIC,
             )
             | Q(
                 parent_dataset__project__members=self.request.user.id,
+                parent_dataset__visibility=VisibilityChoices.PUBLIC,
                 viewers=self.request.user.id,
-                visibility="RESTRICTED",
+                visibility=VisibilityChoices.RESTRICTED,
+            )
+            | Q(
+                parent_dataset__project__members=self.request.user.id,
+                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                parent_dataset__viewers=self.request.user.id,
+                viewers=self.request.user.id,
+                visibility=VisibilityChoices.RESTRICTED,
             )
         )
 
@@ -305,12 +315,12 @@ class DatasetListView(generics.ListAPIView):
         return Dataset.objects.filter(
             Q(
                 project__members=self.request.user.id,
-                visibility="PUBLIC",
+                visibility=VisibilityChoices.PUBLIC,
             )
             | Q(
                 project__members=self.request.user.id,
                 viewers=self.request.user.id,
-                visibility="RESTRICTED",
+                visibility=VisibilityChoices.RESTRICTED,
             )
         )
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -243,7 +243,7 @@ class ScanReportListViewSet(viewsets.ModelViewSet):
         which are "PUBLIC", or "RESTRICTED" ScanReports that a user is a viewer of.
         """
         if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
-            return ScanReport.objects.all()
+            return ScanReport.objects.all().distinct()
 
         return ScanReport.objects.filter(
             Q(
@@ -264,7 +264,7 @@ class ScanReportListViewSet(viewsets.ModelViewSet):
                 viewers=self.request.user.id,
                 visibility=VisibilityChoices.RESTRICTED,
             )
-        )
+        ).distinct()
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(


### PR DESCRIPTION
# Changes
- `views.ScanReportListViewset` now only returns:
  - public scan reports in public datasets on projects the user is in
  - restricted scan reports the user is a viewer of, on public datasets, on projects the user is in
  - restricted scan reports this user is a viewer of, on restricted datasets the user is a viewer of, on projects the user is in
- `views.ScanReportListViewset` will still return all scan reports for the `AZ_FUNCTION_USER`