### PR TITLE
Refactor mapping reuse code

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -450,7 +450,9 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
     existing_field_name_to_id_map = {}
     for name in list(new_fields_map.keys()):
         mappings_matching_field_name = [
-            mapping for mapping in existing_mappings_to_consider if mapping["name"] == name
+            mapping
+            for mapping in existing_mappings_to_consider
+            if mapping["name"] == name
         ]
         target_concept_ids = set(
             [mapping["concept"] for mapping in mappings_matching_field_name]
@@ -1363,9 +1365,7 @@ def post_field_entries(field_entries_to_post, api_url, scan_report_id, headers):
                 )
             )
 
-        fields_response_content += json.loads(
-            fields_response.content.decode("utf-8")
-        )
+        fields_response_content += json.loads(fields_response.content.decode("utf-8"))
 
     print(
         "POST fields all finished",

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -346,7 +346,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         element.get("object_id", None): str(element.get("concept", None))
         for element in field_concept_ids
     }
-    print("FIELD TO CONCEPT MAP DICT", field_id_to_concept_map)
+    # print("FIELD TO CONCEPT MAP DICT", field_id_to_concept_map)
     # creates a list of field ids from fields that already exist
     existing_ids = list(field_id_to_concept_map.keys())
     # paginate the field id's variable and field names from list of newly generated
@@ -367,7 +367,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         )
         fields.append(json.loads(get_field_names.content.decode("utf-8")))
     fields = flatten(fields)
-    print("FIELDS", fields)
+    # print("FIELDS", fields)
 
     # get a list of table ids for all the fields that have matching names
     table_ids = set([item["scan_report_table"] for item in fields])
@@ -383,7 +383,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         )
         tables.append(json.loads(get_field_tables.content.decode("utf-8")))
     tables = flatten(tables)
-    print("TABLES", tables)
+    # print("TABLES", tables)
     # map table id's to scanreport id
 
     # get all scanreports to be used to check active scan reports
@@ -416,7 +416,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
     fields = [
         item for item in fields if str(item["id"]) in field_id_to_active_scanreport_map
     ]
-    print("FILTERED FIELDS", fields)
+    # print("FILTERED FIELDS", fields)
 
     existing_mappings = [
         {
@@ -426,7 +426,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         }
         for field in fields
     ]
-    print("EXISTING MAPPINGS", existing_mappings)
+    # print("EXISTING MAPPINGS", existing_mappings)
     field_name_to_id_map = {}
     for name in list(new_fields_map.keys()):
         mappings_matching_field_name = [
@@ -444,10 +444,10 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
     # replace field_name_to_id_map with field name to concept id map
     # field_name_to_concept_id_map = { element.key: field_id_to_concept_map[int(element.value)] for element in field_name_to_id_map }
 
-    print("FIELD NAME TO ID MAP", field_name_to_id_map)
+    # print("FIELD NAME TO ID MAP", field_name_to_id_map)
     concepts_to_post = []
     concept_response_content = []
-    print("NAME IDS", new_fields_map.keys())
+    # print("NAME IDS", new_fields_map.keys())
 
     for name, id in new_fields_map.items():
         try:
@@ -728,7 +728,10 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
 
         concept_response_content += concept_content
 
-        print("POST concepts all finished", datetime.utcnow().strftime("%H:%M:%S.%fZ"))
+        print(
+            datetime.utcnow().strftime("%H:%M:%S.%fZ"),
+            "POST concepts all finished in reuse_existing_value_concepts",
+        )
 
 
 def remove_BOM(intermediate):
@@ -1405,11 +1408,13 @@ def main(msg: func.QueueMessage):
                     headers,
                 )
             )
-
+    print("All tables completed. Now set status to 'Upload Complete'")
     # Set the status to 'Upload Complete'
     status_complete_response = requests.patch(
         url=f"{api_url}scanreports/{scan_report_id}/",
         data=json.dumps({"status": "UPCOMPL"}),
         headers=headers,
     )
+    print("Successfully set status to 'Upload Complete'")
     wb.close()
+    print("Workbook successfully closed")

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -236,8 +236,11 @@ def paginate_two_lists(entries, other, max_chars=None):
 
     paginated_entries = paginate(entries, max_chars / 2)
     paginated_other = paginate(other, max_chars / 2)
-    return [(page_entries, page_other) for page_entries in
-            paginated_entries for page_other in paginated_other]
+    return [
+        (page_entries, page_other)
+        for page_entries in paginated_entries
+        for page_other in paginated_other
+    ]
 
 
 # @memory_profiler.profile(stream=profiler_logstream)
@@ -348,9 +351,9 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
     existing_ids = list(field_id_to_concept_map.keys())
     # paginate the field id's variable and field names from list of newly generated
     # fields so that get request does not exceed character limit
-    paginated_ids_and_new_field_names = paginate_two_lists(existing_ids,
-                                                           list(new_fields_map.keys()),
-                                                           max_chars_for_get)
+    paginated_ids_and_new_field_names = paginate_two_lists(
+        existing_ids, list(new_fields_map.keys()), max_chars_for_get
+    )
     # for each list in paginated ids, get scanreport fields that match any of the given
     # ids and matches any of the newly generated names
     fields = []
@@ -359,7 +362,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         new_fields_names = ",".join(map(str, t[1]))
         get_field_names = requests.get(
             url=f"{api_url}scanreportfieldsfilter/?id__in={ids_to_get}&name__in="
-                f"{new_fields_names}",
+            f"{new_fields_names}",
             headers=headers,
         )
         fields.append(json.loads(get_field_names.content.decode("utf-8")))
@@ -492,7 +495,10 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
 
         concept_response_content += concept_content
 
-        print("POST concepts all finished", datetime.utcnow().strftime("%H:%M:%S.%fZ"))
+        print(
+            "POST concepts all finished in reuse_existing_field_concepts",
+            datetime.utcnow().strftime("%H:%M:%S.%fZ"),
+        )
 
 
 def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers):
@@ -557,8 +563,8 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
         new_values_names = ",".join(map(str, t[1]))
         get_value_names = requests.get(
             url=f"{api_url}scanreportvaluesfilter/?id__in={ids_to_get}&value__in="
-                f"{new_values_names}&fields=id,value,scan_report_field,"
-                f"value_description",
+            f"{new_values_names}&fields=id,value,scan_report_field,"
+            f"value_description",
             headers=headers,
         )
         existing_scanreport_values.append(


### PR DESCRIPTION
Initially, this started out as
- Refactor the pagination code to enable a 2-dimensional pagination of two lists. This includes extracting the maximum characters for a GET request to a variable, removing the unused paginate_chars(), adding handle_max_chars() to reuse code, and changing the signature of paginate() as it no longer handles 2 lists.

However, the full PR goes further and applies some further refactoring and bug fixing.