### PR TITLE
add `X-CSRFToken` header to `usePatch` and `usePost`

### DIFF
--- a/react-client-app/package.json
+++ b/react-client-app/package.json
@@ -31,6 +31,7 @@
     "axios": "^0.25.0",
     "formik": "^2.2.9",
     "framer-motion": "^4.1.17",
+    "js-cookie": "^3.0.1",
     "moment": "^2.29.1",
     "plotly.js": "^2.5.1",
     "react": "^17.0.2",

--- a/react-client-app/src/api/values.js
+++ b/react-client-app/src/api/values.js
@@ -1,3 +1,6 @@
+import Cookies from 'js-cookie';
+import Cookie from 'js-cookie'
+
 const m_allowed_tables = ['person','measurement','condition_occurrence','observation','drug_exposure','procedure_occurrence']
 
 // function to fetch from api with authorization token
@@ -11,7 +14,10 @@ const usePost = async (url,data) =>{
     const response = await fetch(`/api${url}`,
     {
         method: "POST",
-        headers: {'Content-Type': 'application/json; charset=utf-8'},
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            'X-CSRFToken': Cookies.get('csrftoken'),
+        },
         body: JSON.stringify(data)    
     }
     );
@@ -23,7 +29,10 @@ const usePatch = async (url, body) => {
     const response = await fetch(`/api${url}`,
         {
             method: "PATCH",
-            headers: {'Content-Type': 'application/json; charset=utf-8'},
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'X-CSRFToken': Cookies.get('csrftoken'),
+            },
             body: JSON.stringify(body)
         }
     );


### PR DESCRIPTION
# Changes
- Install `js-cookie 3.0.1`
- Extract CSRF token from cookies and send with `POST`/`PATCH` requests to fix 403 Forbidden bug introduced in #396 