### PR TITLE
Feature/dataset admins

### DIFF
--- a/api/mapping/management/commands/add_admins_to_datasets.py
+++ b/api/mapping/management/commands/add_admins_to_datasets.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from mapping.models import DataPartner, Dataset
+from mapping.models import Dataset
 
 
 class Command(BaseCommand):
@@ -19,4 +19,20 @@ class Command(BaseCommand):
         and setting the author as an admin.
         """
 
-        pass
+        dataset_names = options.get("datasets")
+
+        if dataset_names:
+            print(f"Finding admins for {len(dataset_names)} dataset(s)...")
+            datasets = Dataset.objects.filter(admins=None, name__in=dataset_names)
+
+        else:
+            print(f"No datasets given. Finding admins for all datasets...")
+            datasets = Dataset.objects.filter(admins=None)
+
+        for ds in datasets:
+            print(f"Adding admins to {ds.name}")
+            authors = [
+                author
+                for author in ds.scan_reports.all().values_list("author", flat=True)
+            ]
+            ds.admins.add(*authors)

--- a/api/mapping/management/commands/add_admins_to_datasets.py
+++ b/api/mapping/management/commands/add_admins_to_datasets.py
@@ -4,7 +4,15 @@ from mapping.models import DataPartner, Dataset
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        pass
+        parser.add_argument(
+            "datasets",
+            default=[],
+            nargs="*",
+            help="""(Optional) The names of the dataset(s) to add an admin.
+            By default find all datasets with no admins and add the authors of the
+            scan reports in the dataset.
+            """,
+        )
 
     def handle(self, *args, **options):
         """Logic for finding the first scan report of a dataset

--- a/api/mapping/management/commands/add_admins_to_datasets.py
+++ b/api/mapping/management/commands/add_admins_to_datasets.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from mapping.models import DataPartner, Dataset
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        pass
+
+    def handle(self, *args, **options):
+        """Logic for finding the first scan report of a dataset
+        and setting the author as an admin.
+        """
+
+        pass

--- a/api/mapping/management/commands/add_datasets_to_partner.py
+++ b/api/mapping/management/commands/add_datasets_to_partner.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from mapping.models import DataPartner, Dataset, ScanReport, Project
+from mapping.models import DataPartner, Dataset
 
 
 class Command(BaseCommand):

--- a/api/mapping/models.py
+++ b/api/mapping/models.py
@@ -411,6 +411,12 @@ class Dataset(BaseModel):
         related_query_name="dataset_viewing",
         blank=True,
     )
+    admins = models.ManyToManyField(
+        settings.AUTH_USER_MODEL,
+        related_name="dataset_admins",
+        related_query_name="dataset_admin",
+        blank=True,
+    )
     # `projects` field added by M2M field in `Project`
     # `scan_reports` field added by FK field in `ScanReport`
 

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -49,6 +49,23 @@ class CanViewDataset(permissions.BasePermission):
         return False
 
 
+class CanAdminDataset(permissions.BasePermission):
+    message = "You are not an admin of this Dataset."
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Return `True` in any of the following cases:
+            - the User is the `AZ_FUNCTION_USER`
+            - the User is in the Dataset's `admins` field
+        """
+        # if the User is the `AZ_FUNCTION_USER` grant permission
+        if request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return True
+        # if the User is in the Dataset's admins, return True,
+        # else return false
+        return obj.objects.filter(admins=request.user.id).exists()
+
+
 class CanViewScanReport(permissions.BasePermission):
     message = "You do not have permission to view this scan report"
 

--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -63,7 +63,7 @@ class CanAdminDataset(permissions.BasePermission):
             return True
         # if the User is in the Dataset's admins, return True,
         # else return false
-        return obj.objects.filter(admins=request.user.id).exists()
+        return obj.admins.filter(id=request.user.id).exists()
 
 
 class CanViewScanReport(permissions.BasePermission):

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -128,8 +128,8 @@ class TestCanViewDataset(TestCase):
 
     def test_non_project_member_cannot_view(self):
         # Make the requests for the Dataset
-        request1 = self.factory.get(f"api/datasets/{self.restricted_dataset.id}")
-        request2 = self.factory.get(f"api/datasets/{self.public_dataset.id}")
+        request1 = self.factory.get(f"/api/datasets/{self.restricted_dataset.id}")
+        request2 = self.factory.get(f"/api/datasets/{self.public_dataset.id}")
         # Add the user to the requests; this is not automatic
         request1.user = self.user_without_perm
         request2.user = self.user_without_perm
@@ -160,7 +160,7 @@ class TestCanViewDataset(TestCase):
 
     def test_restricted_viewership(self):
         # Make the request for the Dataset
-        request = self.factory.get(f"api/datasets/{self.restricted_dataset.id}")
+        request = self.factory.get(f"/api/datasets/{self.restricted_dataset.id}")
         # Add the user to the request; this is not automatic
         request.user = self.restricted_user
         # Authenticate the restricted user
@@ -192,7 +192,7 @@ class TestCanViewDataset(TestCase):
 
     def test_public_viewership(self):
         # Make the request for the Dataset
-        request = self.factory.get(f"api/datasets/{self.public_dataset.id}")
+        request = self.factory.get(f"/api/datasets/{self.public_dataset.id}")
         # Add the user to the request; this is not automatic
         request.user = self.restricted_user
         # Authenticate the restricted user
@@ -226,7 +226,7 @@ class TestCanViewDataset(TestCase):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
         # Make the request for the Dataset
-        request = self.factory.get(f"api/datasets/{self.restricted_dataset.id}")
+        request = self.factory.get(f"/api/datasets/{self.restricted_dataset.id}")
         # Add the user to the request; this is not automatic
         request.user = az_user
         # Authenticate az_user
@@ -242,7 +242,7 @@ class TestCanViewDataset(TestCase):
             )
         )
         # Make the request for the Dataset
-        request = self.factory.get(f"api/datasets/{self.public_dataset.id}")
+        request = self.factory.get(f"/api/datasets/{self.public_dataset.id}")
         # Add the user to the request; this is not automatic
         request.user = az_user
         # Authenticate az_user
@@ -297,7 +297,7 @@ class TestCanAdminDataset(TestCase):
         self.permission = CanAdminDataset()
 
     def test_only_admin_user_can_view(self):
-        request = self.factory.patch(f"api/datasets/update/{self.dataset.id}")
+        request = self.factory.patch(f"/api/datasets/update/{self.dataset.id}")
         request.user = self.admin_user
         # Authenticate the user for the request
         force_authenticate(
@@ -325,7 +325,7 @@ class TestCanAdminDataset(TestCase):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
         # Make the request for the Dataset
-        request = self.factory.get(f"api/datasets/update/{self.dataset.id}")
+        request = self.factory.get(f"/api/datasets/update/{self.dataset.id}")
         # Add the user to the request; this is not automatic
         request.user = az_user
         # Authenticate az_user
@@ -397,8 +397,10 @@ class TestCanViewScanReport(TestCase):
 
     def test_non_project_member_cannot_view(self):
         # Make the requests for the Scan Report
-        request1 = self.factory.get(f"api/scanreports/{self.restricted_scan_report.id}")
-        request2 = self.factory.get(f"api/scanreports/{self.public_scan_report.id}")
+        request1 = self.factory.get(
+            f"/api/scanreports/{self.restricted_scan_report.id}"
+        )
+        request2 = self.factory.get(f"/api/scanreports/{self.public_scan_report.id}")
         # Add the user to the requests; this is not automatic
         request1.user = self.user_without_perm
         request2.user = self.user_without_perm
@@ -429,7 +431,7 @@ class TestCanViewScanReport(TestCase):
 
     def test_restricted_viewership(self):
         # Make the request for the Scan Report
-        request = self.factory.get(f"api/scanreports/{self.restricted_scan_report.id}")
+        request = self.factory.get(f"/api/scanreports/{self.restricted_scan_report.id}")
         # Add the user to the request; this is not automatic
         request.user = self.restricted_user
         # Authenticate the restricted user
@@ -461,7 +463,7 @@ class TestCanViewScanReport(TestCase):
 
     def test_public_viewership(self):
         # Make the request for the Scan Report
-        request = self.factory.get(f"api/scanreports/{self.public_scan_report.id}")
+        request = self.factory.get(f"/api/scanreports/{self.public_scan_report.id}")
         # Add the user to the request; this is not automatic
         request.user = self.restricted_user
         # Authenticate the restricted user
@@ -495,7 +497,7 @@ class TestCanViewScanReport(TestCase):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
         # Make the request for the Scan Report
-        request = self.factory.get(f"api/scanreports/{self.restricted_scan_report.id}")
+        request = self.factory.get(f"/api/scanreports/{self.restricted_scan_report.id}")
         # Add the user to the request; this is not automatic
         request.user = az_user
         # Authenticate az_user
@@ -511,7 +513,7 @@ class TestCanViewScanReport(TestCase):
             )
         )
         # Make the request for the Scan Report
-        request = self.factory.get(f"api/scanreports/{self.public_scan_report.id}")
+        request = self.factory.get(f"/api/scanreports/{self.public_scan_report.id}")
         # Add the user to the request; this is not automatic
         request.user = az_user
         # Authenticate az_user

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -53,7 +53,7 @@ class TestDatasetListView(TestCase):
 
     def test_dataset_returns(self):
         # Make the request for Datasets
-        request = self.factory.get(f"api/datasets/")
+        request = self.factory.get(f"/api/datasets/")
         # Add user1 to the request; this is not automatic
         request.user = self.user1
         # Authenticate the user1
@@ -102,7 +102,7 @@ class TestDatasetListView(TestCase):
     def test_dataset_filtering(self):
         # Make the request for the public_dataset1
         request = self.factory.get(
-            f"api/datasets/", {"id__in": self.public_dataset1.id}
+            f"/api/datasets/", {"id__in": self.public_dataset1.id}
         )
         # Add user1 to the request; this is not automatic
         request.user = self.user1
@@ -122,7 +122,7 @@ class TestDatasetListView(TestCase):
 
         # Make the request for the public_dataset3
         request = self.factory.get(
-            f"api/datasets/", {"id__in": self.public_dataset3.id}
+            f"/api/datasets/", {"id__in": self.public_dataset3.id}
         )
         # Add user1 to the request; this is not automatic
         request.user = self.user1
@@ -142,7 +142,7 @@ class TestDatasetListView(TestCase):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
         # Make the request for the Dataset
-        request = self.factory.get(f"api/datasets/")
+        request = self.factory.get(f"/api/datasets/")
         # Add the user to the request; this is not automatic
         request.user = az_user
         # Authenticate az_user
@@ -183,12 +183,29 @@ class TestDatasetUpdateView(TestCase):
             name="The Heights of Hobbits", visibility=VisibilityChoices.PUBLIC
         )
         self.dataset.admins.add(self.admin_user)
+        self.project.datasets.add(self.dataset)
 
         # Request factory for setting up requests
         self.factory = APIRequestFactory()
 
         # The view for the tests
         self.view = DatasetUpdateView.as_view()
+
+    def test_update_returns(self):
+        request = self.factory.patch(
+            f"/api/datasets/update/{self.dataset.id}", data={"name": "The Two Towers"}
+        )
+        request.user = self.admin_user
+        # Authenticate the user for the request
+        force_authenticate(
+            request,
+            user=self.admin_user,
+            token=self.admin_user.auth_token,
+        )
+        response = self.view(request)
+        response_data = response.data
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data.get("name"), "The Two Towers")
 
 
 class TestScanScanReportListViewset(TestCase):

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -200,6 +200,7 @@ class TestDatasetUpdateView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_data.get("name"), "The Two Towers")
 
+    def test_non_admin_member_forbidden(self):
         # Authenticate non admin user
         self.client.force_authenticate(self.non_admin_user)
         #  Make the request

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -209,6 +209,16 @@ class TestDatasetUpdateView(TestCase):
         # Ensure non admin user is Forbidden
         self.assertEqual(response.status_code, 403)
 
+    def test_non_project_member_forbidden(self):
+        # Authenticate non project user
+        self.client.force_authenticate(self.non_project_user)
+        #  Make the request
+        response = self.client.patch(
+            f"/api/datasets/update/{self.dataset.id}", data={"name": "The Two Towers"}
+        )
+        # Ensure non project user is Forbidden
+        self.assertEqual(response.status_code, 403)
+
 
 class TestScanScanReportListViewset(TestCase):
     def setUp(self):

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -151,7 +151,7 @@ urlpatterns = [
     ),
     path(
         r"api/datasets/create/",
-        views.CreateDatasetView.as_view(),
+        views.DatasetCreateView.as_view(),
         name="dataset_create",
     ),
     # path(

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -147,7 +147,12 @@ urlpatterns = [
     path(
         r"api/datasets/<int:pk>",
         views.DatasetRetrieveView.as_view(),
-        name="datasets_retrieve",
+        name="dataset_retrieve",
+    ),
+    path(
+        r"api/datasets/update/<int:pk>",
+        views.DatasetUpdateView.as_view(),
+        name="dataset_update",
     ),
     path(
         r"api/datasets/create/",

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -139,6 +139,7 @@ urlpatterns = [
         views.CountStatsScanReportTableField.as_view(),
         name="countstatsscanreporttablefield",
     ),
+    # Dataset views
     path(
         r"api/datasets/",
         views.DatasetListView.as_view(),
@@ -153,6 +154,11 @@ urlpatterns = [
         r"api/datasets/update/<int:pk>",
         views.DatasetUpdateView.as_view(),
         name="dataset_update",
+    ),
+    path(
+        r"api/datasets/delete/<int:pk>",
+        views.DatasetDeleteView.as_view(),
+        name="dataset_delete",
     ),
     path(
         r"api/datasets/create/",

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -341,7 +341,7 @@ class DatasetRetrieveView(generics.RetrieveAPIView):
     permission_classes = [CanViewDataset]
 
     def get_queryset(self):
-        qs = Dataset.objects.filter(id=self.kwargs.get("id"))
+        qs = Dataset.objects.filter(id=self.kwargs.get("pk"))
         return qs
 
 
@@ -351,7 +351,7 @@ class DatasetUpdateView(generics.UpdateAPIView):
     permission_classes = [CanViewDataset & CanAdminDataset]
 
     def get_queryset(self):
-        qs = Dataset.objects.filter(id=self.kwargs.get("id"))
+        qs = Dataset.objects.filter(id=self.kwargs.get("pk"))
         return qs
 
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -113,6 +113,7 @@ from .models import (
 from .permissions import (
     CanViewProject,
     CanViewDataset,
+    CanAdminDataset,
     CanViewScanReport,
 )
 from .services import download_data_dictionary_blob
@@ -326,7 +327,7 @@ class DatasetListView(generics.ListAPIView):
         ).distinct()
 
 
-class CreateDatasetView(generics.CreateAPIView):
+class DatasetCreateView(generics.CreateAPIView):
     serializer_class = DatasetSerializer
     queryset = Dataset.objects.all()
 
@@ -340,7 +341,17 @@ class DatasetRetrieveView(generics.RetrieveAPIView):
     permission_classes = [CanViewDataset]
 
     def get_queryset(self):
-        qs = Dataset.objects.filter(id=self.kwargs["pk"])
+        qs = Dataset.objects.filter(id=self.kwargs.get("id"))
+        return qs
+
+
+class DatasetUpdateView(generics.UpdateAPIView):
+    serializer_class = DatasetSerializer
+    # User must be able to view and be an admin
+    permission_classes = [CanViewDataset & CanAdminDataset]
+
+    def get_queryset(self):
+        qs = Dataset.objects.filter(id=self.kwargs.get("id"))
         return qs
 
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -355,6 +355,16 @@ class DatasetUpdateView(generics.UpdateAPIView):
         return qs
 
 
+class DatasetDeleteView(generics.DestroyAPIView):
+    serializer_class = DatasetSerializer
+    # User must be able to view and be an admin
+    permission_classes = [CanViewDataset & CanAdminDataset]
+
+    def get_queryset(self):
+        qs = Dataset.objects.filter(id=self.kwargs.get("pk"))
+        return qs
+
+
 class ScanReportTableViewSet(viewsets.ModelViewSet):
     queryset = ScanReportTable.objects.all()
     serializer_class = ScanReportTableSerializer

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,13 @@ Please append a line to the changelog for each change made.
     2. Create a migration adding a `ManyToManyField` called `viewers` to __Dataset__ linking it to `settings.AUTH_USER_MODEL`.
     3. Create a migration to add the `visibility` flag to __ScanReport__. Set default to "PUBLIC".
     4. Create a migration adding a `ManyToManyField` called `viewers` to __ScanReport__ linking it to `settings.AUTH_USER_MODEL`.
+* Implemented admins and associated permissions to Datasets.
+  * Admins can update and delete Datasets.
+  * __IMPORTANT!__ Steps to enact this change:
+    1. Create a migration adding a `ManyToManyField` called `admins` to __Dataset__ linking it to `settings.AUTH_USER_MODEL`.
+* Added API views for updating and deleting Datasets.
+  * Use `PATCH` `/api/datasets/update/<dataset id>` to update.
+  * Use `DELETE` `/api/datasets/delete/<dataset id>` to delete.
 
 ## v1.4.0 was released 02/02/22
 * Mapping rules within existing Scan Reports that are (a) set to 'Mapping Complete' and (b) not 

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Please append a line to the changelog for each change made.
   * Admins can update and delete Datasets.
   * __IMPORTANT!__ Steps to enact this change:
     1. Create a migration adding a `ManyToManyField` called `admins` to __Dataset__ linking it to `settings.AUTH_USER_MODEL`.
+    2. Run the management command `add_admins_to_datasets` with no arguments to assign a single admin to each existing dataset.
 * Added API views for updating and deleting Datasets.
   * Use `PATCH` `/api/datasets/update/<dataset id>` to update.
   * Use `DELETE` `/api/datasets/delete/<dataset id>` to delete.


### PR DESCRIPTION
# Changes
* Added `admins` M2M field to `Dataset` linking to User model.
* Created `CanAdminDataset` permission class.
* Created `DatasetUpdateView` and `DatasetDeleteView` views. 
  * These require `CanViewDataset` __and__ `CanAdminDataset` permissions
* Added `add_admins_to_datasets` management command.

# Migrations
* add `admins` M2M field to `Dataset` model. Link to `settings.AUTH_USER_MODEL`