### PR TITLE
View perms include admins

### DIFF
--- a/api/mapping/permissions.py
+++ b/api/mapping/permissions.py
@@ -99,3 +99,25 @@ class CanViewScanReport(permissions.BasePermission):
             ).exists()
 
         return False
+
+
+class CanEditScanReport(permissions.BasePermission):
+    message = "You do not have permission to edit this Scan Report."
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Return `True` in any of the following cases:
+            - the User is the `AZ_FUNCTION_USER`
+            - (unimplmented) the User is in the Scan Report's `editors` field
+            - the User is in the parent Dataset's `admins` field
+        """
+        # if the User is the `AZ_FUNCTION_USER` grant permission
+        if request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return True
+
+        # TODO: add check for the User being in the editors field
+        # once it is implemented.
+
+        # if the User is in the parent Dataset's admins, return True,
+        # else return false
+        return obj.parent_dataset.admins.filter(id=request.user.id).exists()

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -284,7 +284,7 @@ class TestCanAdminDataset(TestCase):
             name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
         )
         # Add the restricted users
-        self.dataset.viewers.add(self.admin_user)
+        self.dataset.viewers.add(self.non_admin_user)
         self.dataset.admins.add(self.admin_user)
         # Add datasets to the project
         self.project.datasets.add(self.dataset)

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -8,6 +8,7 @@ from .permissions import (
     CanViewDataset,
     CanAdminDataset,
     CanViewScanReport,
+    CanEditScanReport,
 )
 from .views import (
     ProjectRetrieveView,
@@ -15,7 +16,7 @@ from .views import (
     DatasetUpdateView,
     ScanReportRetrieveView,
 )
-from .models import Project, Dataset, ScanReport
+from .models import Project, Dataset, ScanReport, VisibilityChoices
 
 
 class TestCanViewProject(TestCase):
@@ -528,3 +529,66 @@ class TestCanViewScanReport(TestCase):
                 request, self.view, self.public_scan_report
             )
         )
+
+
+class TestCanEditScanReport(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        # Create user who can see the Dataset whether restricted or public
+        self.restricted_user = User.objects.create(
+            username="gandalf", password="thegrey"
+        )
+        # Give them a token
+        Token.objects.create(user=self.restricted_user)
+
+        # Create user who can see the Dataset when public only
+        self.public_user = User.objects.create(username="aragorn", password="elissar")
+        # Give them a token
+        Token.objects.create(user=self.public_user)
+
+        # Create user who cannot access the Project
+        self.user_without_perm = User.objects.create(
+            username="balrog", password="youshallnotpass"
+        )
+        # Give them a token
+        Token.objects.create(user=self.user_without_perm)
+
+        # Create user who can see the scan report because they're an admin
+        # of the parent dataset
+        self.ds_admin_user = User.objects.create(username="saruman", password="thewise")
+        # Give them a token
+        Token.objects.create(user=self.ds_admin_user)
+
+        # Create the project
+        self.project = Project.objects.create(name="The Fellowship of the Ring")
+        # Add the permitted users
+        self.project.members.add(self.public_user, self.restricted_user)
+        # Create the dataset
+        self.dataset = Dataset.objects.create(
+            name="Hobbits of the Fellowship", visibility="PUBLIC"
+        )
+        self.dataset.admins.add(self.ds_admin_user)
+        # Create the public scan report
+        self.public_scan_report = ScanReport.objects.create(
+            dataset="Hobbit Heights",
+            visibility="PUBLIC",
+            parent_dataset=self.dataset,
+        )
+        # Create the restricted scan report
+        self.restricted_scan_report = ScanReport.objects.create(
+            dataset="Hobbit Diaries",
+            visibility="RESTRICTED",
+            parent_dataset=self.dataset,
+        )
+        # Add restriced user to restriced scan report
+        self.restricted_scan_report.viewers.add(self.restricted_user)
+        # Add dataset to the project
+        self.project.datasets.add(self.dataset)
+
+        # Request factory for setting up requests
+        self.factory = APIRequestFactory()
+        # The instance of the view required for the permission class
+        self.view = ScanReportRetrieveView.as_view()
+
+        # The permission class
+        self.permission = CanEditScanReport()

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -574,3 +574,46 @@ class TestCanEditScanReport(TestCase):
 
         # The permission class
         self.permission = CanEditScanReport()
+
+    def test_only_admin_user_can_view(self):
+        request = self.factory.get(f"/api/scanreport/{self.scan_report.id}")
+        request.user = self.admin_user
+        # Authenticate the user for the request
+        force_authenticate(
+            request,
+            user=self.admin_user,
+            token=self.admin_user.auth_token,
+        )
+        # Assert admin_user has permission
+        self.assertTrue(
+            self.permission.has_object_permission(request, self.view, self.scan_report)
+        )
+        request.user = self.non_admin_user
+        # Authenticate the user for the request
+        force_authenticate(
+            request,
+            user=self.non_admin_user,
+            token=self.non_admin_user.auth_token,
+        )
+        # Assert non_admin_user has no permission
+        self.assertFalse(
+            self.permission.has_object_permission(request, self.view, self.scan_report)
+        )
+
+    def test_az_function_user_perm(self):
+        User = get_user_model()
+        az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
+        # Make the request for the Dataset
+        request = self.factory.get(f"/api/scanreport/{self.scan_report.id}")
+        # Add the user to the request; this is not automatic
+        request.user = az_user
+        # Authenticate az_user
+        force_authenticate(
+            request,
+            user=az_user,
+            token=az_user.auth_token,
+        )
+        # Assert az_user has permission on restricted view
+        self.assertTrue(
+            self.permission.has_object_permission(request, self.view, self.scan_report)
+        )

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -108,11 +108,11 @@ class TestCanViewDataset(TestCase):
         self.project.members.add(self.public_user, self.restricted_user)
         # Create the public dataset
         self.public_dataset = Dataset.objects.create(
-            name="Hobbits of the Fellowship", visibility="PUBLIC"
+            name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
         )
         # Create the restricted dataset
         self.restricted_dataset = Dataset.objects.create(
-            name="Ring bearers", visibility="RESTRICTED"
+            name="Ring bearers", visibility=VisibilityChoices.RESTRICTED
         )
         # Add the restricted users
         self.restricted_dataset.viewers.add(self.restricted_user)
@@ -281,7 +281,7 @@ class TestCanAdminDataset(TestCase):
         self.project.members.add(self.non_admin_user, self.admin_user)
         # Create the public dataset
         self.dataset = Dataset.objects.create(
-            name="Hobbits of the Fellowship", visibility="PUBLIC"
+            name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
         )
         # Add the restricted users
         self.dataset.viewers.add(self.admin_user)
@@ -369,18 +369,18 @@ class TestCanViewScanReport(TestCase):
         self.project.members.add(self.public_user, self.restricted_user)
         # Create the dataset
         self.dataset = Dataset.objects.create(
-            name="Hobbits of the Fellowship", visibility="PUBLIC"
+            name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
         )
         # Create the public scan report
         self.public_scan_report = ScanReport.objects.create(
             dataset="Hobbit Heights",
-            visibility="PUBLIC",
+            visibility=VisibilityChoices.PUBLIC,
             parent_dataset=self.dataset,
         )
         # Create the restricted scan report
         self.restricted_scan_report = ScanReport.objects.create(
             dataset="Hobbit Diaries",
-            visibility="RESTRICTED",
+            visibility=VisibilityChoices.RESTRICTED,
             parent_dataset=self.dataset,
         )
         # Add restriced user to restriced scan report
@@ -565,19 +565,19 @@ class TestCanEditScanReport(TestCase):
         self.project.members.add(self.public_user, self.restricted_user)
         # Create the dataset
         self.dataset = Dataset.objects.create(
-            name="Hobbits of the Fellowship", visibility="PUBLIC"
+            name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
         )
         self.dataset.admins.add(self.ds_admin_user)
         # Create the public scan report
         self.public_scan_report = ScanReport.objects.create(
             dataset="Hobbit Heights",
-            visibility="PUBLIC",
+            visibility=VisibilityChoices.PUBLIC,
             parent_dataset=self.dataset,
         )
         # Create the restricted scan report
         self.restricted_scan_report = ScanReport.objects.create(
             dataset="Hobbit Diaries",
-            visibility="RESTRICTED",
+            visibility=VisibilityChoices.RESTRICTED,
             parent_dataset=self.dataset,
         )
         # Add restriced user to restriced scan report

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -449,3 +449,67 @@ class TestScanScanReportListViewset(TestCase):
         response_data = self.view(request).data
         # Assert az_user can see all scan reports
         self.assertEqual(len(response_data), ScanReport.objects.all().count())
+
+
+class TestScanReportRetrieveView(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        # Set up users
+        self.ds_admin_user = User.objects.create(
+            username="gandalf", password="hjfiwejfiwef"
+        )
+        Token.objects.create(user=self.ds_admin_user)
+        self.non_ds_admin_user = User.objects.create(
+            username="aragorn", password="djfoiejwiofjoiewf"
+        )
+        Token.objects.create(user=self.non_ds_admin_user)
+        self.non_project_user = User.objects.create(
+            username="bilbo", password="djfoiejwiofjoiewf"
+        )
+        Token.objects.create(user=self.non_project_user)
+
+        # Set up Project
+        self.project = Project.objects.create(name="The Fellowship of the Ring")
+        self.project.members.add(self.ds_admin_user, self.non_ds_admin_user)
+
+        # Set up Dataset
+        self.dataset = Dataset.objects.create(
+            name="The Heights of Hobbits", visibility=VisibilityChoices.PUBLIC
+        )
+        self.dataset.admins.add(self.ds_admin_user)
+        self.project.datasets.add(self.dataset)
+
+        # Set up Scan Report
+        self.scan_report = ScanReport.objects.create(
+            dataset="The Rings of Power",
+            visibility=VisibilityChoices.RESTRICTED,
+            parent_dataset=self.dataset,
+        )
+        self.scan_report.viewers.add(self.non_ds_admin_user)
+
+        # Request factory for setting up requests
+        self.client = APIClient()
+
+    def test_non_ds_admin_member_can_see(self):
+        # Authenticate non ds admin user
+        self.client.force_authenticate(self.non_ds_admin_user)
+        #  Make the request
+        response = self.client.get(f"/api/scanreports/{self.scan_report.id}")
+        # Ensure non ds admin user can see
+        self.assertEqual(response.status_code, 200)
+
+    def test_ds_admin_member_can_see(self):
+        # Authenticate ds admin user
+        self.client.force_authenticate(self.ds_admin_user)
+        #  Make the request
+        response = self.client.get(f"/api/scanreports/{self.scan_report.id}")
+        # Ensure ds admin user can see
+        self.assertEqual(response.status_code, 200)
+
+    def test_non_project_member_forbidden(self):
+        # Authenticate non project user
+        self.client.force_authenticate(self.non_project_user)
+        #  Make the request
+        response = self.client.get(f"/api/scanreports/{self.scan_report.id}")
+        # Ensure non project user is Forbidden
+        self.assertEqual(response.status_code, 403)

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -221,6 +221,63 @@ class TestDatasetUpdateView(TestCase):
         self.assertEqual(response.status_code, 403)
 
 
+class TestDatasetRetrieveView(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        # Set up users
+        self.admin_user = User.objects.create(
+            username="gandalf", password="hjfiwejfiwef"
+        )
+        Token.objects.create(user=self.admin_user)
+        self.non_admin_user = User.objects.create(
+            username="aragorn", password="djfoiejwiofjoiewf"
+        )
+        Token.objects.create(user=self.non_admin_user)
+        self.non_project_user = User.objects.create(
+            username="bilbo", password="djfoiejwiofjoiewf"
+        )
+        Token.objects.create(user=self.non_project_user)
+
+        # Set up Project
+        self.project = Project.objects.create(name="The Fellowship of the Ring")
+        self.project.members.add(self.admin_user, self.non_admin_user)
+
+        # Set up Dataset
+        self.dataset = Dataset.objects.create(
+            name="The Heights of Hobbits", visibility=VisibilityChoices.RESTRICTED
+        )
+        self.dataset.viewers.add(self.non_admin_user)
+        self.dataset.admins.add(self.admin_user)
+        self.project.datasets.add(self.dataset)
+
+        # Request factory for setting up requests
+        self.client = APIClient()
+
+    def test_non_admin_member_can_see(self):
+        # Authenticate non admin user
+        self.client.force_authenticate(self.non_admin_user)
+        #  Make the request
+        response = self.client.get(f"/api/datasets/{self.dataset.id}")
+        # Ensure non admin user can see
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_member_can_see(self):
+        # Authenticate admin user
+        self.client.force_authenticate(self.admin_user)
+        #  Make the request
+        response = self.client.get(f"/api/datasets/{self.dataset.id}")
+        # Ensure admin user can see
+        self.assertEqual(response.status_code, 200)
+
+    def test_non_project_member_forbidden(self):
+        # Authenticate non project user
+        self.client.force_authenticate(self.non_project_user)
+        #  Make the request
+        response = self.client.get(f"/api/datasets/update/{self.dataset.id}")
+        # Ensure non project user is Forbidden
+        self.assertEqual(response.status_code, 403)
+
+
 class TestDatasetDeleteView(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -273,7 +273,7 @@ class TestDatasetRetrieveView(TestCase):
         # Authenticate non project user
         self.client.force_authenticate(self.non_project_user)
         #  Make the request
-        response = self.client.get(f"/api/datasets/update/{self.dataset.id}")
+        response = self.client.get(f"/api/datasets/{self.dataset.id}")
         # Ensure non project user is Forbidden
         self.assertEqual(response.status_code, 403)
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -111,6 +111,7 @@ from .models import (
     VisibilityChoices,
 )
 from .permissions import (
+    CanEditScanReport,
     CanViewProject,
     CanViewDataset,
     CanAdminDataset,
@@ -299,7 +300,7 @@ class ScanReportRetrieveView(generics.RetrieveAPIView):
     """
 
     serializer_class = ScanReportSerializer
-    permission_classes = [CanViewScanReport]
+    permission_classes = [CanViewScanReport | CanEditScanReport]
 
     def get_queryset(self):
         qs = ScanReport.objects.filter(id=self.kwargs["pk"])

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -352,7 +352,7 @@ class DatasetRetrieveView(generics.RetrieveAPIView):
     """
 
     serializer_class = DatasetSerializer
-    permission_classes = [CanViewDataset]
+    permission_classes = [CanViewDataset | CanAdminDataset]
 
     def get_queryset(self):
         qs = Dataset.objects.filter(id=self.kwargs.get("pk"))


### PR DESCRIPTION
# Changes
- Users with Dataset admin permission can view a dataset or scan report whether it is Public or Restricted
  - User must be in `admins` field or the dataset
  - User must be in the `admins` field of the scan report's `parent_dataset`