### PR TITLE
Fix DataDictionary creation to match new model

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1121,8 +1121,7 @@ class ScanReportFormView(FormView):
         else:
             data_dictionary = DataDictionary.objects.create(
                 name=f"{os.path.splitext(str(form.cleaned_data.get('data_dictionary_file')))[0]}"
-                f"_{dt}{rand}.csv",
-                scan_report=scan_report,
+                f"_{dt}{rand}.csv"
             )
             data_dictionary.save()
             scan_report.data_dictionary = data_dictionary


### PR DESCRIPTION
DataDictionary foreign key to scan_report was removed from the model, so removed the link to scan_report in ScanReportFormView where we create a data dictionary