### PR TITLE
fixed mapping json download

### DIFF
--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -614,7 +614,7 @@ def get_mapping_rules_json(structural_mapping_rules):
     # add the metadata and cdm object together
     return {"metadata": metadata, "cdm": cdm}
 
- 
+
 def download_mapping_rules(request, qs):
     # get the mapping rules
     output = get_mapping_rules_json(qs)

--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -642,7 +642,7 @@ def download_mapping_rules_as_csv(request, qs):
     return_type = "csv"
     fname = f"{scan_report.parent_dataset.data_partner.name}_{scan_report.dataset}_structural_mapping.{return_type}"
     # return a response that downloads the csv file
-
+ 
     # make a string buffer
     _buffer = io.StringIO()
     # setup a csv writter
@@ -650,7 +650,7 @@ def download_mapping_rules_as_csv(request, qs):
         _buffer,
         lineterminator="\n",
         delimiter=",",
-        quoting=csv.QUOTE_NONE,
+        quoting=csv.QUOTE_MINIMAL,
     )
 
     # setup the headers from the first object

--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -614,7 +614,7 @@ def get_mapping_rules_json(structural_mapping_rules):
     # add the metadata and cdm object together
     return {"metadata": metadata, "cdm": cdm}
 
-
+ 
 def download_mapping_rules(request, qs):
     # get the mapping rules
     output = get_mapping_rules_json(qs)
@@ -622,7 +622,7 @@ def download_mapping_rules(request, qs):
     scan_report = qs[0].scan_report
     # make a file name
     return_type = "json"
-    fname = f"{scan_report.data_partner.name}_{scan_report.dataset}_structural_mapping.{return_type}"
+    fname = f"{scan_report.parent_dataset.data_partner.name}_{scan_report.dataset}_structural_mapping.{return_type}"
     # return a response that downloads the json file
 
     response = HttpResponse(
@@ -640,7 +640,7 @@ def download_mapping_rules_as_csv(request, qs):
     scan_report = qs[0].scan_report
     # make a csv file name
     return_type = "csv"
-    fname = f"{scan_report.data_partner.name}_{scan_report.dataset}_structural_mapping.{return_type}"
+    fname = f"{scan_report.parent_dataset.data_partner.name}_{scan_report.dataset}_structural_mapping.{return_type}"
     # return a response that downloads the csv file
 
     # make a string buffer

--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -642,7 +642,7 @@ def download_mapping_rules_as_csv(request, qs):
     return_type = "csv"
     fname = f"{scan_report.parent_dataset.data_partner.name}_{scan_report.dataset}_structural_mapping.{return_type}"
     # return a response that downloads the csv file
- 
+
     # make a string buffer
     _buffer = io.StringIO()
     # setup a csv writter


### PR DESCRIPTION
# Changes

- Fixed broken downloading of mapping json and downloading of mapping csv caused by model changes


# Migrations

# Screenshots
- The pull request fixes the bug caused by the migration changes, but I have found that download mapping csv for 
/scanreports/40/mapping_rules/
still throws an unrelated error.
I believe it is thrown on this line inside services_rules.py with this value inside the content variable
<img width="633" alt="image" src="https://user-images.githubusercontent.com/38753056/157854921-2a12011d-610f-4dc8-ac47-ffc3fb9f615f.png">
<img width="742" alt="image" src="https://user-images.githubusercontent.com/38753056/157854993-29d36159-74b5-49e1-8fba-83e35731b278.png">

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
