### PR TITLE
Change from table to grid, truncate long table names, remove unnecessary variables

### DIFF
--- a/react-client-app/src/components/AnalysisTbl.jsx
+++ b/react-client-app/src/components/AnalysisTbl.jsx
@@ -1,110 +1,80 @@
 import React from 'react'
 import {
-    Table,
-    Thead,
-    Tbody,
-    Tr,
-    Th,
-    Td,
-    TableCaption,
-    VStack,
     Flex,
     Link,
     Grid,
-    GridItem
+    Text,
+    GridItem,
 } from "@chakra-ui/react"
+const truncate = (str) => {
+    return str.length > 20 ? str.substring(0, 20) + "..." : str;
+}
+function AnalysisTbl({ data }) {
 
-
-
-function AnalysisTbl({ data, values, filters }) {
     return (
-        <div>
-            <Table variant="striped" colorScheme="greyBasic">
-                <Thead>
-                    <Tr>
-                        <Th>Rule Id</Th>
-                        <Th>
-                            <span style={{ color: "#475da7" }}>Ancestors</span> / 
-                            <span style={{ color: "#3db28c" }}> Descendants</span>
-                        </Th>
-                        <Th>Min/Max Separation</Th>
-                        <Th>Source</Th>
-                    </Tr>
-                </Thead>
-                <Tbody>
-                    {(data).length > 0 ?
-                        data.map((item, index) =>
-                            <Tr key={index}>
-                                <Td>{item.rule_id} - {item.rule_name}</Td>
-                                <Td>
+        <Grid templateColumns="repeat(4, 1fr)" gap={6} >
 
+            <Text fontWeight={"bold"}>Rule ID</Text>
+            <Text fontWeight={"bold"}>
+                <span style={{ color: "#475da7" }}>Ancestors</span> /
+                <span style={{ color: "#3db28c" }}> Descendants</span>
+            </Text>
+            <Text fontWeight={"bold"} textAlignVertical={"center"} textAlign={"center"}>Min/Max Separation</Text>
+            <Text fontWeight={"bold"}>Source</Text>
+
+
+            {
+                (data).length > 0 ?
+                    data.map((item, index) =>
+                        <GridItem colSpan={4} w={"100%"} bg={index % 2 == 0 ? 'greyBasic.100' : 'greyBasic.500'} >
+                            <Grid templateColumns="repeat(4, 1fr)">
+                                <Text>{item.rule_id} - {item.rule_name}</Text>
+                                <GridItem colSpan={3} >
                                     {item.anc_desc.map((element) =>
-                                        <div>
+                                        <Grid templateColumns="repeat(3, 1fr)">
                                             {element.ancestors.map(ancestor =>
+                                                <>
+                                                    <Text style={{ color: "#475da7" }}> {ancestor.a_id} - {ancestor.a_name} (A)</Text>
+                                                    <Text style={{ color: "#475da7", textAlignVertical: "center", textAlign: "center" }}> {ancestor.level} </Text>
+                                                    <div style={{ alignSelf: 'flex-start' }}>
+                                                        {ancestor.source.map(source_id => {
 
-                                                <div style={{ color: "#475da7" }}> {ancestor.a_id} - {ancestor.a_name} (A)</div>
+                                                            if (source_id.concept__content_type == 15)
+                                                                return <Text><Link style={{ color: "#0000FF", }} href={"/fields/?search=" + source_id.source_field__scan_report_table__id}> {truncate(source_id.source_field__name)} </Link> </Text>
+                                                            return <Text><Link style={{ color: "#0000FF", }} href={"/values/?search=" + source_id.source_field__id}> {truncate(source_id.source_field__name)} </Link></Text>
+                                                        })}
+                                                    </div>
 
+                                                </>
                                             )}
+
                                             {element.descendants.map(descendant =>
+                                                <>
+                                                    <Text style={{ color: "#3db28c" }} > {descendant.d_id} - {descendant.d_name} (D)</Text>
+                                                    <div style={{ color: "#3db28c", textAlignVertical: "center", textAlign: "center" }} > {descendant.level}</div>
+                                                    <div style={{ alignSelf: 'flex-start' }}>
+                                                        {descendant.source.map(source_id => {
 
-                                                <div style={{ color: "#3db28c" }} > {descendant.d_id} - {descendant.d_name} (D)</div>
+                                                            if (source_id.concept__content_type == 15)
+                                                                return <Link style={{ color: "#0000FF", }} href={"/fields/?search=" + source_id.source_field__scan_report_table__id}> {source_id.source_field__name} </Link>
+                                                            return <Link style={{ color: "#0000FF", }} href={"/values/?search=" + source_id.source_field__id}> {source_id.source_field__name} </Link>
+                                                        })}
+                                                    </div>
+                                                </>
+
                                             )}
-                                        </div>
+                                        </Grid>
                                     )}
-                                </Td>
-                                <Td>
-                                    {item.anc_desc.map((element) =>
-                                        <div>
-                                            {element.ancestors.map(ancestor =>
-
-                                                <div style={{ color: "#475da7" }}> {ancestor.level}</div>
-
-                                            )}
-                                            {element.descendants.map(descendant =>
-
-                                                <div style={{ color: "#3db28c" }} > {descendant.level}</div>
-                                            )}
-                                        </div>
-                                    )}
-                                </Td>
-                                <Td>
-                                    {item.anc_desc.map((element) =>
-                                        <div>
-                                            {element.ancestors.map(ancestor =>
-                                                <div style={{ alignSelf: 'flex-start' }}>
-                                                    {ancestor.source.map(source_id => {
-                                                        if (source_id.concept__content_type == 15)
-                                                            return <Link style={{ color: "#0000FF", }} href={"/fields/?search=" + source_id.source_field__scan_report_table__id}> {source_id.source_field__name} </Link>
-                                                        return <Link style={{ color: "#0000FF", }} href={"/values/?search=" + source_id.source_field__id}> {source_id.source_field__name} </Link>
-                                                    })}
-                                                </div>
-
-                                            )}
-                                            {element.descendants.map(descendant =>
-                                                <div style={{ alignSelf: 'flex-start' }}>
-                                                    {descendant.source.map(source_id => {
-                                                        if (source_id.concept__content_type == 15)
-                                                            return <Link style={{ color: "#0000FF", }} href={"/fields/?search=" + source_id.source_field__scan_report_table__id}> {source_id.source_field__name} </Link>
-                                                        return <Link style={{ color: "#0000FF", }} href={"/values/?search=" + source_id.source_field__id}> {source_id.source_field__name} </Link>
-                                                    })}
-                                                </div>
-
-                                            )}
-                                        </div>
-                                    )}
-                                </Td>
-                            </Tr>
-
-                        ) :
-                        <Flex padding="30px">
-                            <Flex marginLeft="10px">No ancestors or descendants of these mappings appear in any other Scan Reports</Flex>
-                        </Flex>
-
-                    }
-                </Tbody>
-
-            </Table>
-        </div>)
+                                </GridItem>
+                            </Grid>
+                        </GridItem >
+                    ) :
+                    <Flex padding="30px">
+                        <Flex marginLeft="10px">No ancestors or descendants of these mappings appear in any other Scan Reports</Flex>
+                    </Flex>
+            }
+        </Grid >
+    )
 }
 
 export default AnalysisTbl;

--- a/react-client-app/src/components/ConceptAnalysis.jsx
+++ b/react-client-app/src/components/ConceptAnalysis.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import AnalysisTbl from './AnalysisTbl'
 
-function ConceptAnalysis({data, values, filters}) {
-    
+function ConceptAnalysis({ data }) {
+
     return (
         <div>
-            <AnalysisTbl data={data} values={values}filters={filters}/>
+            <AnalysisTbl data={data} />
         </div>
     )
 }

--- a/react-client-app/src/components/MappingTbl.jsx
+++ b/react-client-app/src/components/MappingTbl.jsx
@@ -329,7 +329,7 @@ const MappingTbl = () => {
                     destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} />
             </MappingModal>
             <AnalysisModal isOpenAnalyse={isOpenAnalyse} onOpenAnalyse={onOpenAnalyse} onCloseAnalyse={onCloseAnalyse}>
-                <ConceptAnalysis data={data} values={values} filters={filters} />
+                <ConceptAnalysis data={data} />
             </AnalysisModal>
             <HStack my="10px">
                 <Button variant="green" onClick={() => { refreshRules() }}>Refresh Rules</Button>


### PR DESCRIPTION

# Changes

- Change from table to grid so the source fields are aligned with the ancestors/descendants
-  When field names are too big they don't go to the next line/change up the alignment so I truncate them after 20 chars to prevent that.

## Before Truncating (see Cardiac Arrhythmia)
<img width="1313" alt="Screenshot 2022-03-17 at 13 59 54" src="https://user-images.githubusercontent.com/75254435/158855188-968ea2b1-4deb-462b-b77b-f0e8e6e91b63.png">

## After Truncating (see Cardiac Arrhythmia)
<img width="1292" alt="Screenshot 2022-03-17 at 17 06 51" src="https://user-images.githubusercontent.com/75254435/158855438-2e7ca4fd-184f-406c-9a00-dde5ff5b3415.png">

- Each row alternates with grey and white, the same colour scheme as the tables to match and separate the rules

# Migrations
No migrations

# Screenshots
 ## The final view
<img width="1295" alt="Screenshot 2022-03-17 at 16 57 22" src="https://user-images.githubusercontent.com/75254435/158856200-3f17c107-a58f-4c68-a7e0-4e8dd4a74437.png">

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
