### PR TITLE
Feature/scan report admin page

### DIFF
--- a/api/mapping/templates/mapping/admin_scanreport_form.html
+++ b/api/mapping/templates/mapping/admin_scanreport_form.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+        <li class="breadcrumb-item"><a href="{% url 'scan-report-list' %}">Scan
+                reports</a></li>
+    </ol>
+</nav>
+
+<div>
+    <div id='root'></div>
+    <script type="text/javascript" >
+        var isAdmin = "{{is_admin}}" === "True" ? true : false
+    </script>
+    <script type="module" src="../../../static/javascript/react/src/datasetAdminPage.js"></script>
+
+</div>
+{% endblock %}

--- a/api/mapping/templates/mapping/admin_scanreport_form.html
+++ b/api/mapping/templates/mapping/admin_scanreport_form.html
@@ -15,7 +15,7 @@
     <script type="text/javascript" >
         var isAdmin = "{{is_admin}}" === "True" ? true : false
     </script>
-    <script type="module" src="../../../static/javascript/react/src/datasetAdminPage.js"></script>
+    <script type="module" src="../../../static/javascript/react/src/scanReportAdminPage.js"></script>
 
 </div>
 {% endblock %}

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -223,9 +223,9 @@ urlpatterns = [
         name="scan-report-form",
     ),
     path(
-        "scanreports/<int:pk>/admin",
+        "scanreports/<int:pk>/details",
         views.scanreport_admin_page,
-        name="scan-report-admin-form",
+        name="scan-report-details-form",
     ),
     path(
         "scanreports/<int:pk>/assertions/",

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -223,6 +223,11 @@ urlpatterns = [
         name="scan-report-form",
     ),
     path(
+        "scanreports/<int:pk>/admin",
+        views.scanreport_admin_page,
+        name="scan-report-admin-form",
+    ),
+    path(
         "scanreports/<int:pk>/assertions/",
         views.ScanReportAssertionView.as_view(),
         name="scan-report-assertion",

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1743,3 +1743,18 @@ def dataset_admin_page(request, pk):
         args["is_admin"] = False
 
     return render(request, "mapping/admin_dataset_form.html", args)
+
+
+@login_required
+def scanreport_admin_page(request, pk):
+    args = {}
+    if sr := ScanReport.objects.get(id=pk):
+        is_admin = (
+            sr.author.id == request.user.id
+            or sr.parent_dataset.admins.filter(id=request.user.id).exists()
+        )
+        args["is_admin"] = is_admin
+    else:
+        args["is_admin"] = False
+
+    return render(request, "mapping/admin_scanreport_form.html", args)

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -265,7 +265,7 @@ class ScanReportListViewSet(viewsets.ModelViewSet):
         return [permission() for permission in self.permission_classes]
 
     def get_serializer_class(self):
-        if self.request.method == "GET":
+        if self.request.method in ["GET", "POST"]:
             # use the view serialiser if on GET requests
             return ScanReportViewSerializer
         if self.request.method in ["PUT", "PATCH", "DELETE"]:

--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,13 @@ Please append a line to the changelog for each change made.
     1. Create a migration adding a `ManyToManyField` called `editors` to **Dataset** linking it to `settings.AUTH_USER_MODEL`.
     2. Create a migration adding a `ManyToManyField` called `editors` to **ScanReport** linking it to `settings.AUTH_USER_MODEL`.
 * Added `arraysEqual` function to the React code to test arrays have all the same values.
+* Created new reusable form components:
+  - `CCTextInput`: for text inputs.
+  - `CCSwitchInput`: for boolean switches.
+  - `CCSelectInput`: for selecting a single choice.
+  - `CCMultiSelectInput`: for selecting multiple choices.
+* Added admin form for Scan Reports on frontend.
+  - Found at `/scanreports/<scanreport_id>/admin`.
 
 ## v1.4.0 was released 02/02/22
 

--- a/changelog.md
+++ b/changelog.md
@@ -55,7 +55,7 @@ Please append a line to the changelog for each change made.
   - `CCSelectInput`: for selecting a single choice.
   - `CCMultiSelectInput`: for selecting multiple choices.
 * Added admin form for Scan Reports on frontend.
-  - Found at `/scanreports/<scanreport_id>/admin`.
+  - Found at `/scanreports/<scanreport_id>/details`.
 
 ## v1.4.0 was released 02/02/22
 

--- a/react-client-app/src/App.jsx
+++ b/react-client-app/src/App.jsx
@@ -10,6 +10,7 @@ import TablesTbl from './components/TablesTbl';
 import EditTable from './components/EditTable';
 import EditField from './components/EditField';
 import ScanReportTbl from './components/ScanReportTbl';
+import ScanReportAdminForm from './views/ScanReportAdminForm'
 import Home from './components/Home';
 import { getScanReportConcepts, m_allowed_tables, useDelete, useGet, usePost, mapConceptToOmopField, saveMappingRules } from './api/values'
 import UploadScanReport from './components/UploadScanReport'
@@ -267,6 +268,8 @@ const App = ({ page }) => {
                 return <UploadScanReport setTitle={setTitle} />
             case "Dataset Admin":
                 return <DatasetAdminForm setTitle={setTitle} />
+            case "Scan Report Admin":
+                return <ScanReportAdminForm setTitle={setTitle} />
             default:
                 return <ScanReportTbl setTitle={setTitle} />
         }

--- a/react-client-app/src/components/CCMultiSelectInput.jsx
+++ b/react-client-app/src/components/CCMultiSelectInput.jsx
@@ -12,10 +12,10 @@ const CCMultiSelectInput = (props) => {
      *  label (String): the text for the label.
      *  selectOptions (Array): the options to choose from.
      *  handleInput (Function): the action to perform when the input changes.
-     *  handleDelete (Function): the action to perform to remove choices.
      * 
      * Optional args:
-     *  currentSelections (Array): choices that are already selected.
+     *  currentSelections (Array): choices that are already selected. Default: `[]`
+     *  isDisabled (Boolean): input is disabled or not. Default: `false`
      */
     // Check for required arguments
     if (!props.id) {

--- a/react-client-app/src/components/CCMultiSelectInput.jsx
+++ b/react-client-app/src/components/CCMultiSelectInput.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
     Flex, FormControl, FormLabel, FormErrorMessage, Select
 } from "@chakra-ui/react"
@@ -31,15 +31,16 @@ const CCMultiSelectInput = (props) => {
     if (!props.handleInput || typeof (props.handleInput) !== 'function') {
         throw "`handleInput` must be a function."
     }
-    // Check handleInput is defined and a functions
-    if (!props.handleDelete || typeof (props.handleDelete) !== 'function') {
-        throw "`handleDelete` must be a function."
-    }
+
+    // Check optional arguments
+    const [currentSelections, setCurrentSelections] = useState(
+        props.currentSelections ? props.currentSelections : []
+    )
 
     return (
         <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
             <Flex flexWrap={true}>
-                <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel>
+                <FormLabel htmlFor={props.id} w="200px" style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
                 {currentSelections.map((item, index) => {
                     return (
                         <div key={index} style={{ marginTop: "0px" }}>
@@ -48,24 +49,31 @@ const CCMultiSelectInput = (props) => {
                                 conceptId={""}
                                 conceptIdentifier={item}
                                 itemId={item}
-                                handleDelete={props.handleDelete}
+                                handleDelete={
+                                    setCurrentSelections(
+                                        () => currentSelections.filter(element => element !== item)
+                                    )
+                                }
                             />
                         </div>
                     )
                 })}
             </Flex>
-            <Select
-                value={"---Select---"}
-                isReadOnly={true}
-                onChange={
-                    (option) => props.handleInput(option.target.value)
-                }
-                isDisabled={props.isDisabled ? props.isDisabled : false}
-            >
-                {props.selectOptions.map((item, index) =>
-                    <option key={index} value={item}>{item}</option>
-                )}
-            </Select>
+            {!props.isDisabled &&
+                <Select
+                    value={"---Select---"}
+                    isReadOnly={true}
+                    onChange={
+                        (e) => props.handleInput(currentSelections)
+                    }
+                    isDisabled={props.isDisabled ? props.isDisabled : false}
+                >
+                    <option disabled>---Select---</option>
+                    {props.selectOptions.map((item, index) =>
+                        <option key={index} value={item}>{item}</option>
+                    )}
+                </Select>
+            }
             {props.formErrors && props.formErrors.length > 0 &&
                 <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
             }

--- a/react-client-app/src/components/CCMultiSelectInput.jsx
+++ b/react-client-app/src/components/CCMultiSelectInput.jsx
@@ -18,6 +18,7 @@ const CCMultiSelectInput = (props) => {
      * Optional args:
      *  currentSelections (Array): choices that are already selected. Default: `[]`
      *  isDisabled (Boolean): input is disabled or not. Default: `false`
+     *  formErrors (Array): the errors to display when the input is invalid. Default: `undefined`
      */
     // Check for required arguments
     if (!props.id) {

--- a/react-client-app/src/components/CCMultiSelectInput.jsx
+++ b/react-client-app/src/components/CCMultiSelectInput.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React from 'react'
+import ConceptTag from './ConceptTag'
 import {
     Flex, FormControl, FormLabel, FormErrorMessage, Select
 } from "@chakra-ui/react"
@@ -12,6 +13,7 @@ const CCMultiSelectInput = (props) => {
      *  label (String): the text for the label.
      *  selectOptions (Array): the options to choose from.
      *  handleInput (Function): the action to perform when the input changes.
+     *  handleDelete (Function): the action to perform to remove a selection.
      * 
      * Optional args:
      *  currentSelections (Array): choices that are already selected. Default: `[]`
@@ -31,29 +33,25 @@ const CCMultiSelectInput = (props) => {
     if (!props.handleInput || typeof (props.handleInput) !== 'function') {
         throw "`handleInput` must be a function."
     }
-
-    // Check optional arguments
-    const [currentSelections, setCurrentSelections] = useState(
-        props.currentSelections ? props.currentSelections : []
-    )
+    // Check handleDelete is defined and a functions
+    if (!props.handleDelete || typeof (props.handleDelete) !== 'function') {
+        throw "`handleDelete` must be a function."
+    }
 
     return (
         <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
             <Flex flexWrap={true}>
-                <FormLabel htmlFor={props.id} w="200px" style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
-                {currentSelections.map((item, index) => {
+                <FormLabel htmlFor={props.id} mr={4} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
+                {props.currentSelections.map((item, index) => {
                     return (
-                        <div key={index} style={{ marginTop: "0px" }}>
+                        <div key={index} style={{ marginTop: "0px", marginBottom: "10px" }}>
                             <ConceptTag
                                 conceptName={item}
                                 conceptId={""}
                                 conceptIdentifier={item}
                                 itemId={item}
-                                handleDelete={
-                                    setCurrentSelections(
-                                        () => currentSelections.filter(element => element !== item)
-                                    )
-                                }
+                                handleDelete={() => props.handleDelete(item)}
+                                readOnly={props.isDisabled}
                             />
                         </div>
                     )
@@ -64,7 +62,7 @@ const CCMultiSelectInput = (props) => {
                     value={"---Select---"}
                     isReadOnly={true}
                     onChange={
-                        (e) => props.handleInput(currentSelections)
+                        (e) => props.handleInput(e.target.value)
                     }
                     isDisabled={props.isDisabled ? props.isDisabled : false}
                 >
@@ -74,10 +72,11 @@ const CCMultiSelectInput = (props) => {
                     )}
                 </Select>
             }
-            {props.formErrors && props.formErrors.length > 0 &&
+            {
+                props.formErrors && props.formErrors.length > 0 &&
                 <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
             }
-        </FormControl>
+        </FormControl >
     )
 }
 

--- a/react-client-app/src/components/CCMultiSelectInput.jsx
+++ b/react-client-app/src/components/CCMultiSelectInput.jsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import {
+    Flex, FormControl, FormLabel, FormErrorMessage, Select
+} from "@chakra-ui/react"
+
+const CCMultiSelectInput = (props) => {
+    /**
+     * Reusable multiple select input component.
+     * 
+     * Required args:
+     *  id (String): the ID for the input.
+     *  label (String): the text for the label.
+     *  selectOptions (Array): the options to choose from.
+     *  handleInput (Function): the action to perform when the input changes.
+     *  handleDelete (Function): the action to perform to remove choices.
+     * 
+     * Optional args:
+     *  currentSelections (Array): choices that are already selected.
+     */
+    // Check for required arguments
+    if (!props.id) {
+        throw "`id` must be defined."
+    }
+    if (!props.label) {
+        throw "`label` must be defined."
+    }
+    if (!props.selectOptions) {
+        throw "`selectOptions` must be defined."
+    }
+    // Check handleInput is defined and a functions
+    if (!props.handleInput || typeof (props.handleInput) !== 'function') {
+        throw "`handleInput` must be a function."
+    }
+    // Check handleInput is defined and a functions
+    if (!props.handleDelete || typeof (props.handleDelete) !== 'function') {
+        throw "`handleDelete` must be a function."
+    }
+
+    return (
+        <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
+            <Flex flexWrap={true}>
+                <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel>
+                {currentSelections.map((item, index) => {
+                    return (
+                        <div key={index} style={{ marginTop: "0px" }}>
+                            <ConceptTag
+                                conceptName={item}
+                                conceptId={""}
+                                conceptIdentifier={item}
+                                itemId={item}
+                                handleDelete={props.handleDelete}
+                            />
+                        </div>
+                    )
+                })}
+            </Flex>
+            <Select
+                value={"---Select---"}
+                isReadOnly={true}
+                onChange={
+                    (option) => props.handleInput(option.target.value)
+                }
+                isDisabled={props.isDisabled ? props.isDisabled : false}
+            >
+                {props.selectOptions.map((item, index) =>
+                    <option key={index} value={item}>{item}</option>
+                )}
+            </Select>
+            {props.formErrors && props.formErrors.length > 0 &&
+                <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
+            }
+        </FormControl>
+    )
+}
+
+export default CCMultiSelectInput

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import {
+    Box, FormControl, FormLabel, FormErrorMessage, Select
+} from "@chakra-ui/react"
+import ConceptTag from './ConceptTag'
+
+const CCSelectInput = (props) => {
+    /**
+     * Reusable text input component.
+     * Required args:
+     *  id (String): the ID for the input
+     *  label (String): the text for the label
+     */
+    // Check for required arguments
+    if (props.id === undefined) {
+        throw "`id` must be defined."
+    }
+    if (props.label === undefined) {
+        throw "`label` must be defined."
+    }
+    if (props.value === undefined) {
+        throw "`value` must be defined."
+    }
+    // Check handleInput is a function if defined
+    if (props.handleInput !== undefined && typeof (props.handleInput) !== 'function') {
+        throw "`handleInput` must be a function."
+    }
+    return (
+        <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
+            <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel >
+            <Select
+                value={JSON.stringify(props.value)}
+                onChange={
+                    (option) => props.handleInput(JSON.parse(option.target.value))
+                }
+                isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+            >
+                {props.selectOptions.map((item, index) =>
+                    <option key={index} value={JSON.stringify(item)}>{item.name}</option>
+                )}
+            </Select>
+            {props.formErrors && props.formErrors.length > 0 &&
+                <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
+            }
+        </FormControl>
+    )
+}
+
+export default CCSelectInput

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -31,7 +31,7 @@ const CCSelectInput = (props) => {
                 <Select
                     value={JSON.stringify(props.value)}
                     onChange={
-                        (option) => props.handleInput(JSON.parse(option.target.value))
+                        (option) => props.handleInput(option.target.value)
                     }
                     isReadOnly={props.isReadOnly ? props.isReadOnly : false}
                 >

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -26,7 +26,7 @@ const CCSelectInput = (props) => {
     }
     return (
         <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
-            <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel>
+            <FormLabel htmlFor={props.id} w="200px" style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
             {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
                 <Select
                     value={props.value}

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -33,7 +33,7 @@ const CCSelectInput = (props) => {
                     onChange={
                         (option) => props.handleInput(option.target.value)
                     }
-                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                    isDisabled={props.isDisabled ? props.isDisabled : false}
                 >
                     {props.selectOptions.map((item, index) =>
                         <option key={index} value={item}>{item}</option>
@@ -42,7 +42,7 @@ const CCSelectInput = (props) => {
                 :
                 <Select
                     value={props.value}
-                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                    isDisabled={props.isDisabled ? props.isDisabled : false}
                 >
                     {props.selectOptions.map((item, index) =>
                         <option key={index} value={item}>{item}</option>

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -29,23 +29,23 @@ const CCSelectInput = (props) => {
             <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel>
             {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
                 <Select
-                    value={JSON.stringify(props.value)}
+                    value={props.value}
                     onChange={
                         (option) => props.handleInput(option.target.value)
                     }
                     isReadOnly={props.isReadOnly ? props.isReadOnly : false}
                 >
                     {props.selectOptions.map((item, index) =>
-                        <option key={index} value={JSON.stringify(item)}>{item.name}</option>
+                        <option key={index} value={item}>{item}</option>
                     )}
                 </Select>
                 :
                 <Select
-                    value={JSON.stringify(props.value)}
+                    value={props.value}
                     isReadOnly={props.isReadOnly ? props.isReadOnly : false}
                 >
                     {props.selectOptions.map((item, index) =>
-                        <option key={index} value={JSON.stringify(item)}>{item.name}</option>
+                        <option key={index} value={item}>{item}</option>
                     )}
                 </Select>
             }

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -27,7 +27,7 @@ const CCSelectInput = (props) => {
     return (
         <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
             <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel>
-            {props.handleInput !== undefined && typeof (props.handleInput) !== 'function' ?
+            {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
                 <Select
                     value={JSON.stringify(props.value)}
                     onChange={

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -26,18 +26,29 @@ const CCSelectInput = (props) => {
     }
     return (
         <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
-            <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel >
-            <Select
-                value={JSON.stringify(props.value)}
-                onChange={
-                    (option) => props.handleInput(JSON.parse(option.target.value))
-                }
-                isReadOnly={props.isReadOnly ? props.isReadOnly : false}
-            >
-                {props.selectOptions.map((item, index) =>
-                    <option key={index} value={JSON.stringify(item)}>{item.name}</option>
-                )}
-            </Select>
+            <FormLabel htmlFor={props.id} w="200px">{props.label}</FormLabel>
+            {props.handleInput !== undefined && typeof (props.handleInput) !== 'function' ?
+                <Select
+                    value={JSON.stringify(props.value)}
+                    onChange={
+                        (option) => props.handleInput(JSON.parse(option.target.value))
+                    }
+                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                >
+                    {props.selectOptions.map((item, index) =>
+                        <option key={index} value={JSON.stringify(item)}>{item.name}</option>
+                    )}
+                </Select>
+                :
+                <Select
+                    value={JSON.stringify(props.value)}
+                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                >
+                    {props.selectOptions.map((item, index) =>
+                        <option key={index} value={JSON.stringify(item)}>{item.name}</option>
+                    )}
+                </Select>
+            }
             {props.formErrors && props.formErrors.length > 0 &&
                 <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
             }

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import {
-    Box, FormControl, FormLabel, FormErrorMessage, Select
+    FormControl, FormLabel, FormErrorMessage, Select
 } from "@chakra-ui/react"
-import ConceptTag from './ConceptTag'
 
 const CCSelectInput = (props) => {
     /**

--- a/react-client-app/src/components/CCSelectInput.jsx
+++ b/react-client-app/src/components/CCSelectInput.jsx
@@ -6,9 +6,16 @@ import {
 const CCSelectInput = (props) => {
     /**
      * Reusable text input component.
+     * 
      * Required args:
-     *  id (String): the ID for the input
-     *  label (String): the text for the label
+     *  id (String): the ID for the input.
+     *  label (String): the text for the label.
+     *  selectOptions (Array): the options to choose from.
+     *  handleInput (Function): the action to perform when the input changes.
+     * 
+     * Optional args:
+     *  isDisabled (Boolean): input is disabled or not. Default: `false`
+     *  formErrors (Array): the errors to display when the input is invalid. Default: `undefined`
      */
     // Check for required arguments
     if (props.id === undefined) {
@@ -17,38 +24,27 @@ const CCSelectInput = (props) => {
     if (props.label === undefined) {
         throw "`label` must be defined."
     }
-    if (props.value === undefined) {
-        throw "`value` must be defined."
+    if (props.selectOptions === undefined) {
+        throw "`selectOptions` must be defined."
     }
-    // Check handleInput is a function if defined
-    if (props.handleInput !== undefined && typeof (props.handleInput) !== 'function') {
+    // Check handleInput is defined and a functions
+    if (!props.handleInput || typeof (props.handleInput) !== 'function') {
         throw "`handleInput` must be a function."
     }
     return (
         <FormControl isInvalid={props.formErrors && props.formErrors.length > 0} mt={4}>
             <FormLabel htmlFor={props.id} w="200px" style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
-            {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
-                <Select
-                    value={props.value}
-                    onChange={
-                        (option) => props.handleInput(option.target.value)
-                    }
-                    isDisabled={props.isDisabled ? props.isDisabled : false}
-                >
-                    {props.selectOptions.map((item, index) =>
-                        <option key={index} value={item}>{item}</option>
-                    )}
-                </Select>
-                :
-                <Select
-                    value={props.value}
-                    isDisabled={props.isDisabled ? props.isDisabled : false}
-                >
-                    {props.selectOptions.map((item, index) =>
-                        <option key={index} value={item}>{item}</option>
-                    )}
-                </Select>
-            }
+            <Select
+                value={props.value}
+                onChange={
+                    (option) => props.handleInput(option.target.value)
+                }
+                isDisabled={props.isDisabled ? props.isDisabled : false}
+            >
+                {props.selectOptions.map((item, index) =>
+                    <option key={index} value={item}>{item}</option>
+                )}
+            </Select>
             {props.formErrors && props.formErrors.length > 0 &&
                 <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
             }

--- a/react-client-app/src/components/CCSwitchInput.jsx
+++ b/react-client-app/src/components/CCSwitchInput.jsx
@@ -33,7 +33,7 @@ const CCSwitchInput = (props) => {
         <FormControl mt={4}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
             <Flex alignItems={"center"}>
-                {props.handleInput !== undefined && typeof (props.handleInput) !== 'function' ?
+                {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
                     <Switch
                         id={props.id}
                         isChecked={props.isChecked ? props.isChecked : false}

--- a/react-client-app/src/components/CCSwitchInput.jsx
+++ b/react-client-app/src/components/CCSwitchInput.jsx
@@ -37,14 +37,14 @@ const CCSwitchInput = (props) => {
                     <Switch
                         id={props.id}
                         isChecked={props.isChecked ? props.isChecked : false}
-                        isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                        isDisabled={props.isDisabled ? props.isDisabled : false}
                         onChange={e => props.handleInput(!props.isChecked)}
                     />
                     :
                     <Switch
                         id={props.id}
                         isChecked={props.isChecked ? props.isChecked : false}
-                        isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                        isDisabled={props.isDisabled ? props.isDisabled : false}
                     />
                 }
                 <Text

--- a/react-client-app/src/components/CCSwitchInput.jsx
+++ b/react-client-app/src/components/CCSwitchInput.jsx
@@ -38,7 +38,7 @@ const CCSwitchInput = (props) => {
                         id={props.id}
                         isChecked={props.isChecked ? props.isChecked : false}
                         isReadOnly={props.isReadOnly ? props.isReadOnly : false}
-                        onChange={e => props.handleInput(e.checked)}
+                        onChange={e => props.handleInput(!props.isChecked)}
                     />
                     :
                     <Switch

--- a/react-client-app/src/components/CCSwitchInput.jsx
+++ b/react-client-app/src/components/CCSwitchInput.jsx
@@ -6,11 +6,17 @@ import {
 const CCSwitchInput = (props) => {
     /**
      * Reusable text input component.
+     * 
      * Required args:
-     *  id (String): the ID for the input
-     *  label (String): the text for the label
-     *  checkedMessage (String): the text to show when checked
-     *  notCheckedMessage (String): the text to show when not checked
+     *  id (String): the ID for the input.
+     *  label (String): the text for the label.
+     *  checkedMessage (String): the text to show when checked.
+     *  notCheckedMessage (String): the text to show when not checked.
+     *  handleInput (Function): the action to perform when the input changes.
+     * 
+     * Optional args:
+     *  isDisabled (Boolean): input is disabled or not. Default: `false`
+     *  formErrors (Array): the errors to display when the input is invalid. Default: `undefined`
      */
     // Check for required arguments
     if (props.id === undefined) {
@@ -25,28 +31,20 @@ const CCSwitchInput = (props) => {
     if (props.notCheckedMessage === undefined) {
         throw "`notCheckedMessage` must be defined."
     }
-    // Check handleInput is a function if defined
-    if (props.handleInput !== undefined && typeof (props.handleInput) !== 'function') {
+    // Check handleInput is defined and a function
+    if (!props.handleInput || typeof (props.handleInput) !== 'function') {
         throw "`handleInput` must be a function."
     }
     return (
         <FormControl mt={4}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
             <Flex alignItems={"center"}>
-                {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
-                    <Switch
-                        id={props.id}
-                        isChecked={props.isChecked ? props.isChecked : false}
-                        isDisabled={props.isDisabled ? props.isDisabled : false}
-                        onChange={e => props.handleInput(!props.isChecked)}
-                    />
-                    :
-                    <Switch
-                        id={props.id}
-                        isChecked={props.isChecked ? props.isChecked : false}
-                        isDisabled={props.isDisabled ? props.isDisabled : false}
-                    />
-                }
+                <Switch
+                    id={props.id}
+                    isChecked={props.isChecked ? props.isChecked : false}
+                    isDisabled={props.isDisabled ? props.isDisabled : false}
+                    onChange={e => props.handleInput(!props.isChecked)}
+                />
                 <Text
                     fontWeight={"bold"}
                     ml={2}

--- a/react-client-app/src/components/CCSwitchInput.jsx
+++ b/react-client-app/src/components/CCSwitchInput.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import {
+    FormControl, FormLabel, Switch
+} from "@chakra-ui/react"
+
+const CCSwitchInput = (props) => {
+    /**
+     * Reusable text input component.
+     * Required args:
+     *  id (String): the ID for the input
+     *  label (String): the text for the label
+     *  checkedMessage (String): the text to show when checked
+     *  notCheckedMessage (String): the text to show when not checked
+     */
+    // Check for required arguments
+    if (props.id === undefined) {
+        throw "`id` must be defined."
+    }
+    if (props.label === undefined) {
+        throw "`label` must be defined."
+    }
+    if (props.checkedMessage === undefined) {
+        throw "`checkedMessage` must be defined."
+    }
+    if (props.notCheckedMessage === undefined) {
+        throw "`notCheckedMessage` must be defined."
+    }
+    // Check handleInput is a function if defined
+    if (props.handleInput !== undefined && typeof (props.handleInput) !== 'function') {
+        throw "`handleInput` must be a function."
+    }
+    return (
+        <FormControl mt={4}>
+            <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
+            <Flex alignItems={"center"}>
+                <Switch
+                    id={props.id}
+                    isChecked={props.isChecked ? props.isChecked : false}
+                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                    onChange={e => props.handleInput(e.checked)}
+                />
+                <Text
+                    fontWeight={"bold"}
+                    ml={2}
+                >
+                    {props.isChecked ? props.checkedMessage : props.notCheckedMessage}
+                </Text>
+            </Flex>
+        </FormControl>
+    )
+}
+
+export default CCSwitchInput

--- a/react-client-app/src/components/CCSwitchInput.jsx
+++ b/react-client-app/src/components/CCSwitchInput.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {
-    FormControl, FormLabel, Switch
+    Flex, FormControl, FormLabel, Switch, Text
 } from "@chakra-ui/react"
 
 const CCSwitchInput = (props) => {
@@ -33,12 +33,20 @@ const CCSwitchInput = (props) => {
         <FormControl mt={4}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
             <Flex alignItems={"center"}>
-                <Switch
-                    id={props.id}
-                    isChecked={props.isChecked ? props.isChecked : false}
-                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
-                    onChange={e => props.handleInput(e.checked)}
-                />
+                {props.handleInput !== undefined && typeof (props.handleInput) !== 'function' ?
+                    <Switch
+                        id={props.id}
+                        isChecked={props.isChecked ? props.isChecked : false}
+                        isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                        onChange={e => props.handleInput(e.checked)}
+                    />
+                    :
+                    <Switch
+                        id={props.id}
+                        isChecked={props.isChecked ? props.isChecked : false}
+                        isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                    />
+                }
                 <Text
                     fontWeight={"bold"}
                     ml={2}

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -28,14 +28,14 @@ const CCTextInput = (props) => {
                 <Input
                     id={props.id}
                     value={props.value}
-                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                    isDisabled={props.isDisabled ? props.isDisabled : false}
                     onChange={e => props.handleInput(e.target.value)}
                 />
                 :
                 <Input
                     id={props.id}
                     value={props.value}
-                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
+                    isDisabled={props.isDisabled ? props.isDisabled : false}
                 />
             }
             {props.formErrors && props.formErrors.length > 0 &&

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -22,7 +22,7 @@ const CCTextInput = (props) => {
         throw "`handleInput` must be a function."
     }
     return (
-        <FormControl mt={props.mt} isInvalid={props.formErrors && props.formErrors.length > 0}>
+        <FormControl mt={4} isInvalid={props.formErrors && props.formErrors.length > 0}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
             {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
                 <Input

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -24,7 +24,7 @@ const CCTextInput = (props) => {
     return (
         <FormControl mt={props.mt} isInvalid={props.formErrors && props.formErrors.length > 0}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
-            {props.handleInput !== undefined && typeof (props.handleInput) !== 'function' ?
+            {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
                 <Input
                     id={props.id}
                     value={props.value}

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -22,7 +22,7 @@ const CCTextInput = (props) => {
         throw "`handleInput` must be a function."
     }
     return (
-        <FormControl mt={4} isInvalid={props.formErrors && props.formErrors.length > 0}>
+        <FormControl mt={props.mt} isInvalid={props.formErrors && props.formErrors.length > 0}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
             {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
                 <Input

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -6,9 +6,15 @@ import {
 const CCTextInput = (props) => {
     /**
      * Reusable text input component.
+     * 
      * Required args:
-     *  id (String): the ID for the input
-     *  label (String): the text for the label
+     *  id (String): the ID for the input.
+     *  label (String): the text for the label.
+     *  handleInput (Function): the action to perform when the input changes.
+     * 
+     * Optional args:
+     *  isDisabled (Boolean): input is disabled or not. Default: `false`
+     *  formErrors (Array): the errors to display when the input is invalid. Default: `undefined`
      */
     // Check for required arguments
     if (props.id === undefined) {
@@ -17,27 +23,19 @@ const CCTextInput = (props) => {
     if (props.label === undefined) {
         throw "`label` must be defined."
     }
-    // Check handleInput is a function if defined
-    if (props.handleInput !== undefined && typeof (props.handleInput) !== 'function') {
+    // Check handleInput is defined and a function
+    if (!props.handleInput || typeof (props.handleInput) !== 'function') {
         throw "`handleInput` must be a function."
     }
     return (
         <FormControl mt={4} isInvalid={props.formErrors && props.formErrors.length > 0}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
-            {props.handleInput !== undefined && typeof (props.handleInput) === 'function' ?
-                <Input
-                    id={props.id}
-                    value={props.value}
-                    isDisabled={props.isDisabled ? props.isDisabled : false}
-                    onChange={e => props.handleInput(e.target.value)}
-                />
-                :
-                <Input
-                    id={props.id}
-                    value={props.value}
-                    isDisabled={props.isDisabled ? props.isDisabled : false}
-                />
-            }
+            <Input
+                id={props.id}
+                value={props.value}
+                isDisabled={props.isDisabled ? props.isDisabled : false}
+                onChange={e => props.handleInput(e.target.value)}
+            />
             {props.formErrors && props.formErrors.length > 0 &&
                 <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
             }

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -22,7 +22,7 @@ const CCTextInput = (props) => {
         throw "`handleInput` must be a function."
     }
     return (
-        <FormControl mt={props.mt} isInvalid={props.formErrors.name && props.formErrors.name.length > 0}>
+        <FormControl mt={props.mt} isInvalid={props.formErrors && props.formErrors.length > 0}>
             <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
             {props.handleInput !== undefined && typeof (props.handleInput) !== 'function' ?
                 <Input
@@ -38,8 +38,8 @@ const CCTextInput = (props) => {
                     readOnly={props.readOnly ? props.readOnly : false}
                 />
             }
-            {props.formErrors.name && props.formErrors.name.length > 0 &&
-                <FormErrorMessage>{props.formErrors.name[0]}</FormErrorMessage>
+            {props.formErrors && props.formErrors.length > 0 &&
+                <FormErrorMessage>{props.formErrors[0]}</FormErrorMessage>
             }
         </FormControl>
     )

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -28,14 +28,14 @@ const CCTextInput = (props) => {
                 <Input
                     id={props.id}
                     value={props.value}
-                    readOnly={props.readOnly ? props.readOnly : false}
+                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
                     onChange={e => props.handleInput(e.target.value)}
                 />
                 :
                 <Input
                     id={props.id}
                     value={props.value}
-                    readOnly={props.readOnly ? props.readOnly : false}
+                    isReadOnly={props.isReadOnly ? props.isReadOnly : false}
                 />
             }
             {props.formErrors && props.formErrors.length > 0 &&

--- a/react-client-app/src/components/CCTextInput.jsx
+++ b/react-client-app/src/components/CCTextInput.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import {
+    Input, FormControl, FormLabel, FormErrorMessage
+} from "@chakra-ui/react"
+
+const CCTextInput = (props) => {
+    /**
+     * Reusable text input component.
+     * Required args:
+     *  id (String): the ID for the input
+     *  label (String): the text for the label
+     */
+    // Check for required arguments
+    if (props.id === undefined) {
+        throw "`id` must be defined."
+    }
+    if (props.label === undefined) {
+        throw "`label` must be defined."
+    }
+    // Check handleInput is a function if defined
+    if (props.handleInput !== undefined && typeof (props.handleInput) !== 'function') {
+        throw "`handleInput` must be a function."
+    }
+    return (
+        <FormControl mt={props.mt} isInvalid={props.formErrors.name && props.formErrors.name.length > 0}>
+            <FormLabel htmlFor={props.id} style={{ fontWeight: "bold" }}>{props.label}</FormLabel>
+            {props.handleInput !== undefined && typeof (props.handleInput) !== 'function' ?
+                <Input
+                    id={props.id}
+                    value={props.value}
+                    readOnly={props.readOnly ? props.readOnly : false}
+                    onChange={e => props.handleInput(e.target.value)}
+                />
+                :
+                <Input
+                    id={props.id}
+                    value={props.value}
+                    readOnly={props.readOnly ? props.readOnly : false}
+                />
+            }
+            {props.formErrors.name && props.formErrors.name.length > 0 &&
+                <FormErrorMessage>{props.formErrors.name[0]}</FormErrorMessage>
+            }
+        </FormControl>
+    )
+}
+
+export default CCTextInput

--- a/react-client-app/src/scanReportAdminPage.jsx
+++ b/react-client-app/src/scanReportAdminPage.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom'
+import App from './App'
+
+ReactDOM.render(<App page="Scan Report Admin" />, document.getElementById('root'));

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -1,8 +1,15 @@
 import React, { useState, useEffect, useRef } from 'react'
+import PageHeading from '../components/PageHeading'
+import ToastAlert from '../components/ToastAlert'
+import ConceptTag from '../components/ConceptTag'
 import CCSelectInput from '../components/CCSelectInput'
 import CCSwitchInput from '../components/CCSwitchInput'
 import CCTextInput from '../components/CCTextInput'
 import { useGet, usePatch, useDelete } from '../api/values'
+import {
+    Select, Box, Text, Button, Flex, Spinner, Container, Input, Tooltip, CloseButton, ScaleFade, useDisclosure, Switch,
+    FormControl, FormLabel, FormErrorMessage
+} from "@chakra-ui/react"
 
 
 const ScanReportAdminForm = ({ setTitle }) => {
@@ -99,10 +106,11 @@ const ScanReportAdminForm = ({ setTitle }) => {
                     <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
                 </ScaleFade>
             }
-            <PageHeading text={`Scan Report #${dataset.id}`} />
+            <PageHeading text={`Scan Report #${scanReport.id}`} />
             <CCTextInput
                 id={"scanreport-name"}
                 label={"Name"}
+                value={scanReport.name}
                 isReadOnly={!isAdmin}
                 formErrors={formErrors.name}
             />
@@ -118,6 +126,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 id={"scanreport-dataset"}
                 label={"Dataset"}
                 value={selectedDataset}
+                selectOptions={datasets}
                 isReadOnly={!isAdmin}
                 formErrors={formErrors.dataset}
             />

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -23,6 +23,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
     const [isAdmin, setIsAdmin] = useState(window.isAdmin)
     const [datasets, setDatasets] = useState();
     const [selectedDataset, setSelectedDataset] = useState()
+    const [author, setAuthor] = useState();
     const [isPublic, setIsPublic] = useState()
     const [loadingMessage, setLoadingMessage] = useState("Loading page")
     const [formErrors, setFormErrors] = useState({})
@@ -67,6 +68,9 @@ const ScanReportAdminForm = ({ setTitle }) => {
             setSelectedDataset(
                 datasetsQuery.find(element => element.id === scanReportQuery.parent_dataset)
             )
+            setAuthor(
+                usersQuery.find(element => element.id == scanReportQuery.author)
+            )
             setIsPublic(scanReportQuery.visibility === "PUBLIC")
             setUsersList(usersQuery)
             setViewers(
@@ -100,9 +104,18 @@ const ScanReportAdminForm = ({ setTitle }) => {
 
     // Update scan report parent dataset
     function handleDatasetSelect(newValue) {
-        const dataset = JSON.parse(newValue)
+        const dataset = datasets.find(el => el.name === newValue)
+        console.log(dataset)
         setSelectedDataset(dataset)
         setScanReport({ ...scanReport, parent_dataset: dataset.id })
+    }
+
+    // Update scan report author
+    function handleAuthorSelect(newValue) {
+        const newAuthor = usersList.find(el => el.username === newValue)
+        console.log(newAuthor)
+        setAuthor(newAuthor)
+        setScanReport({ ...scanReport, author: newAuthor.id })
     }
 
     if (loadingMessage) {
@@ -133,6 +146,15 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 isReadOnly={!isAdmin}
                 formErrors={formErrors.dataset}
             />
+            <CCSelectInput
+                id={"scanreport-author"}
+                label={"Author"}
+                value={author.username}
+                selectOptions={usersList.map(item => item.username)}
+                handleInput={handleAuthorSelect}
+                // isReadOnly={!isAdmin}
+                formErrors={formErrors.dataset}
+            />
             <CCSwitchInput
                 id={"scanreport-visibility"}
                 label={"Visibility"}
@@ -146,7 +168,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 id={"scanreport-dataset"}
                 label={"Dataset"}
                 value={selectedDataset}
-                selectOptions={datasets}
+                selectOptions={datasets.map(item => item.name)}
                 handleInput={handleDatasetSelect}
                 isReadOnly={!isAdmin}
                 formErrors={formErrors.dataset}

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -124,14 +124,14 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 label={"Name"}
                 value={scanReport.dataset}
                 handleInput={handleNameInput}
-                // isReadOnly={!isAdmin}
+                isReadOnly={!isAdmin}
                 formErrors={formErrors.dataset}
             />
             <CCSwitchInput
                 id={"scanreport-visibility"}
                 label={"Visibility"}
                 isChecked={isPublic}
-                // isReadOnly={!isAdmin}
+                isReadOnly={!isAdmin}
                 handleInput={handleVisibilitySwitch}
                 checkedMessage={"PUBLIC"}
                 notCheckedMessage={"RESTRICTED"}

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -1,14 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react'
 import PageHeading from '../components/PageHeading'
 import ToastAlert from '../components/ToastAlert'
-import ConceptTag from '../components/ConceptTag'
+import CCMultiSelectInput from '../components/CCMultiSelectInput'
 import CCSelectInput from '../components/CCSelectInput'
 import CCSwitchInput from '../components/CCSwitchInput'
 import CCTextInput from '../components/CCTextInput'
 import { useGet, usePatch, useDelete } from '../api/values'
 import {
-    Select, Box, Text, Button, Flex, Spinner, Container, Input, Tooltip, CloseButton, ScaleFade, useDisclosure, Switch,
-    FormControl, FormLabel, FormErrorMessage
+    Button, Flex, Spinner, Container, ScaleFade, useDisclosure
 } from "@chakra-ui/react"
 
 
@@ -118,6 +117,16 @@ const ScanReportAdminForm = ({ setTitle }) => {
         setScanReport({ ...scanReport, author: newAuthor.id })
     }
 
+    // Update scan report viewers
+    function handleViewersInput(newViewers) {
+        console.log(newViewers)
+    }
+
+    // Update scan report editors
+    function handleEditorsInput(newEditors) {
+        console.log(newEditors)
+    }
+
     if (loadingMessage) {
         //Render Loading State
         return (
@@ -163,6 +172,24 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 handleInput={handleVisibilitySwitch}
                 checkedMessage={"PUBLIC"}
                 notCheckedMessage={"RESTRICTED"}
+            />
+            {!isPublic &&
+                <CCMultiSelectInput
+                    id={"scanreport-viewers"}
+                    label={"Viewers"}
+                    isDisabled={!isAdmin}
+                    selectOptions={usersList.map(item => item.username)}
+                    currentSelections={viewers.map(item => item.username)}
+                    handleInput={handleViewersInput}
+                />
+            }
+            <CCMultiSelectInput
+                id={"scanreport-editors"}
+                label={"Editors"}
+                isDisabled={!isAdmin}
+                selectOptions={usersList.map(item => item.username)}
+                currentSelections={editors.map(item => item.username)}
+                handleInput={handleEditorsInput}
             />
             <CCSelectInput
                 id={"scanreport-dataset"}

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -87,6 +87,18 @@ const ScanReportAdminForm = ({ setTitle }) => {
     )
 
 
+    // Update dataset name
+    function handleNameInput(newValue) {
+        setScanReport({ ...scanReport, dataset: newValue })
+    }
+
+    // Update dataset visibility
+    function handleVisibilitySwitch(newValue) {
+        console.log(newValue)
+        setIsPublic(newValue)
+        setScanReport({ ...scanReport, visibility: newValue ? "PUBLIC" : "RESTRICTED" })
+    }
+
     if (loadingMessage) {
         //Render Loading State
         return (
@@ -110,15 +122,17 @@ const ScanReportAdminForm = ({ setTitle }) => {
             <CCTextInput
                 id={"scanreport-name"}
                 label={"Name"}
-                value={scanReport.name}
-                isReadOnly={!isAdmin}
-                formErrors={formErrors.name}
+                value={scanReport.dataset}
+                handleInput={handleNameInput}
+                // isReadOnly={!isAdmin}
+                formErrors={formErrors.dataset}
             />
             <CCSwitchInput
                 id={"scanreport-visibility"}
                 label={"Visibility"}
                 isChecked={isPublic}
-                isReadOnly={!isAdmin}
+                // isReadOnly={!isAdmin}
+                handleInput={handleVisibilitySwitch}
                 checkedMessage={"PUBLIC"}
                 notCheckedMessage={"RESTRICTED"}
             />

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -87,16 +87,22 @@ const ScanReportAdminForm = ({ setTitle }) => {
     )
 
 
-    // Update dataset name
+    // Update scan report dataset (the actual name)
     function handleNameInput(newValue) {
         setScanReport({ ...scanReport, dataset: newValue })
     }
 
-    // Update dataset visibility
+    // Update scan report visibility
     function handleVisibilitySwitch(newValue) {
-        console.log(newValue)
         setIsPublic(newValue)
         setScanReport({ ...scanReport, visibility: newValue ? "PUBLIC" : "RESTRICTED" })
+    }
+
+    // Update scan report parent dataset
+    function handleDatasetSelect(newValue) {
+        const dataset = JSON.parse(newValue)
+        setSelectedDataset(dataset)
+        setScanReport({ ...scanReport, parent_dataset: dataset.id })
     }
 
     if (loadingMessage) {
@@ -141,6 +147,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 label={"Dataset"}
                 value={selectedDataset}
                 selectOptions={datasets}
+                handleInput={handleDatasetSelect}
                 isReadOnly={!isAdmin}
                 formErrors={formErrors.dataset}
             />

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -117,14 +117,28 @@ const ScanReportAdminForm = ({ setTitle }) => {
         setScanReport({ ...scanReport, author: newAuthor.id })
     }
 
-    // Update scan report viewers
-    function handleViewersInput(newViewers) {
-        console.log(newViewers)
+    // Add scan report viewers
+    function addViewer(newViewer) {
+        newViewer = usersList.find(el => el.username === newViewer)
+        setViewers(previous => [...previous, newViewer])
+    }
+
+    // Remove a scan report viewer
+    function removeViewer(oldViewer) {
+        const newViewers = viewers.filter(el => el.username !== oldViewer)
+        setViewers(newViewers)
     }
 
     // Update scan report editors
-    function handleEditorsInput(newEditors) {
-        console.log(newEditors)
+    function addEditor(newEditor) {
+        newEditor = usersList.find(el => el.username === newEditor)
+        setEditors(previous => [...previous, newEditor])
+    }
+
+    // Remove a scan report viewer
+    function removeEditor(oldEditor) {
+        const newEditors = editors.filter(el => el.username !== oldEditor)
+        setEditors(newEditors)
     }
 
     if (loadingMessage) {
@@ -180,7 +194,8 @@ const ScanReportAdminForm = ({ setTitle }) => {
                     isDisabled={!isAdmin}
                     selectOptions={usersList.map(item => item.username)}
                     currentSelections={viewers.map(item => item.username)}
-                    handleInput={handleViewersInput}
+                    handleInput={addViewer}
+                    handleDelete={removeViewer}
                 />
             }
             <CCMultiSelectInput
@@ -189,7 +204,8 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 isDisabled={!isAdmin}
                 selectOptions={usersList.map(item => item.username)}
                 currentSelections={editors.map(item => item.username)}
-                handleInput={handleEditorsInput}
+                handleInput={addEditor}
+                handleDelete={removeEditor}
             />
             <CCSelectInput
                 id={"scanreport-dataset"}

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect, useRef } from 'react'
+import CCSelectInput from '../components/CCSelectInput'
+import CCSwitchInput from '../components/CCSwitchInput'
+import CCTextInput from '../components/CCTextInput'
+import { useGet, usePatch, useDelete } from '../api/values'
+
+
+const ScanReportAdminForm = ({ setTitle }) => {
+    const { isOpen, onOpen, onClose } = useDisclosure()
+    const [alert, setAlert] = useState({ hidden: true, title: '', description: '', status: 'error' })
+    const [isAdmin, setIsAdmin] = useState(window.isAdmin)
+    const [dataPartners, setDataPartners] = useState();
+    const [selectedDataPartner, setSelectedDataPartner] = useState()
+    const [isPublic, setIsPublic] = useState()
+    const [loadingMessage, setLoadingMessage] = useState("Loading page")
+    const [formErrors, setFormErrors] = useState({})
+
+
+    if (loadingMessage) {
+        //Render Loading State
+        return (
+            <div>
+                <Flex padding="30px">
+                    <Spinner />
+                    <Flex marginLeft="10px">{loadingMessage ? loadingMessage : "Loading page"}</Flex>
+                </Flex>
+            </div>
+        )
+    }
+
+    return (
+        <Container maxW='container.xl'>
+            {isOpen &&
+                <ScaleFade initialScale={0.9} in={isOpen}>
+                    <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
+                </ScaleFade>
+            }
+            <PageHeading text={`Scan Report #${dataset.id}`} />
+            <CCTextInput
+                id={"scanreport-name"}
+                label={"Name"}
+                isReadOnly={!isAdmin}
+            />
+            <CCSwitchInput
+                id={"scanreport-visibility"}
+                label={"Visibility"}
+                checkedMessage={"PUBLIC"}
+                notCheckedMessage={"RESTRICTED"}
+            />
+            <CCSelectInput
+                id={"scanreport-datapartner"}
+                label={"Data Partner"}
+                isReadOnly={!isAdmin}
+            />
+            <CCSelectInput
+                id={"scanreport-dataset"}
+                label={"Dataset"}
+                isReadOnly={!isAdmin}
+            />
+            {isAdmin &&
+                <Button isLoading={uploadLoading} loadingText='Uploading' mt="10px" onClick={upload}>Submit</Button>
+            }
+        </Container>
+    )
+}
+
+export default ScanReportAdminForm

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -143,7 +143,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 label={"Name"}
                 value={scanReport.dataset}
                 handleInput={handleNameInput}
-                isReadOnly={!isAdmin}
+                isDisabled={!isAdmin}
                 formErrors={formErrors.dataset}
             />
             <CCSelectInput
@@ -152,14 +152,14 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 value={author.username}
                 selectOptions={usersList.map(item => item.username)}
                 handleInput={handleAuthorSelect}
-                // isReadOnly={!isAdmin}
+                isDisabled={!isAdmin}
                 formErrors={formErrors.dataset}
             />
             <CCSwitchInput
                 id={"scanreport-visibility"}
                 label={"Visibility"}
                 isChecked={isPublic}
-                isReadOnly={!isAdmin}
+                isDisabled={!isAdmin}
                 handleInput={handleVisibilitySwitch}
                 checkedMessage={"PUBLIC"}
                 notCheckedMessage={"RESTRICTED"}
@@ -170,7 +170,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 value={selectedDataset}
                 selectOptions={datasets.map(item => item.name)}
                 handleInput={handleDatasetSelect}
-                isReadOnly={!isAdmin}
+                isDisabled={!isAdmin}
                 formErrors={formErrors.dataset}
             />
             {isAdmin &&

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -90,6 +90,42 @@ const ScanReportAdminForm = ({ setTitle }) => {
         [], // Required to stop this effect sending infinite requests
     )
 
+    useEffect(
+        async () => {
+            setFormErrors({ ...formErrors, dataset: undefined })
+        },
+        [scanReport.dataset],
+    )
+
+    useEffect(
+        async () => {
+            setFormErrors({ ...formErrors, author: undefined })
+        },
+        [author],
+    )
+
+    useEffect(
+        async () => {
+            setFormErrors({ ...formErrors, viewers: undefined })
+        },
+        [viewers],
+    )
+
+    useEffect(
+        async () => {
+            setFormErrors({ ...formErrors, editors: undefined })
+        },
+        [editors],
+    )
+
+    useEffect(
+        async () => {
+            setFormErrors({ ...formErrors, parent_dataset: undefined })
+        },
+        [selectedDataset],
+    )
+
+
 
     // Update scan report dataset (the actual name)
     function handleNameInput(newValue) {
@@ -105,7 +141,6 @@ const ScanReportAdminForm = ({ setTitle }) => {
     // Update scan report parent dataset
     function handleDatasetSelect(newValue) {
         const dataset = datasets.find(el => el.name === newValue)
-        console.log(dataset)
         setSelectedDataset(dataset)
         setScanReport({ ...scanReport, parent_dataset: dataset.id })
     }
@@ -113,7 +148,6 @@ const ScanReportAdminForm = ({ setTitle }) => {
     // Update scan report author
     function handleAuthorSelect(newValue) {
         const newAuthor = usersList.find(el => el.username === newValue)
-        console.log(newAuthor)
         setAuthor(newAuthor)
         setScanReport({ ...scanReport, author: newAuthor.id })
     }
@@ -219,7 +253,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 label={"Name"}
                 value={scanReport.dataset}
                 handleInput={handleNameInput}
-                // isDisabled={!isAdmin}
+                isDisabled={!isAdmin}
                 formErrors={formErrors.dataset}
             />
             <CCSelectInput
@@ -249,6 +283,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                     currentSelections={viewers.map(item => item.username)}
                     handleInput={addViewer}
                     handleDelete={removeViewer}
+                    formErrors={formErrors.viewers}
                 />
             }
             <CCMultiSelectInput
@@ -259,6 +294,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 currentSelections={editors.map(item => item.username)}
                 handleInput={addEditor}
                 handleDelete={removeEditor}
+                formErrors={formErrors.editors}
             />
             <CCSelectInput
                 id={"scanreport-dataset"}
@@ -267,9 +303,8 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 selectOptions={datasets.map(item => item.name)}
                 handleInput={handleDatasetSelect}
                 isDisabled={!isAdmin}
-                formErrors={formErrors.dataset}
+                formErrors={formErrors.parent_dataset}
             />
-            <Button isLoading={uploadLoading} loadingText='Uploading' mt="10px" onClick={upload}>Submit</Button>
             {isAdmin &&
                 <Button isLoading={uploadLoading} loadingText='Uploading' mt="10px" onClick={upload}>Submit</Button>
             }

--- a/react-client-app/src/views/ScanReportAdminForm.jsx
+++ b/react-client-app/src/views/ScanReportAdminForm.jsx
@@ -57,6 +57,9 @@ const ScanReportAdminForm = ({ setTitle }) => {
             // Set up state from the results of the queries
             setScanReport(scanReportQuery)
             setDatasets(datasetsQuery)
+            setSelectedDataset(
+                datasetsQuery.find(element => element.id === scanReportQuery.parent_dataset)
+            )
             setIsPublic(scanReportQuery.visibility === "PUBLIC")
             setUsersList(usersQuery)
             setViewers(
@@ -101,6 +104,7 @@ const ScanReportAdminForm = ({ setTitle }) => {
                 id={"scanreport-name"}
                 label={"Name"}
                 isReadOnly={!isAdmin}
+                formErrors={formErrors.name}
             />
             <CCSwitchInput
                 id={"scanreport-visibility"}
@@ -113,8 +117,9 @@ const ScanReportAdminForm = ({ setTitle }) => {
             <CCSelectInput
                 id={"scanreport-dataset"}
                 label={"Dataset"}
-                value={ }
+                value={selectedDataset}
                 isReadOnly={!isAdmin}
+                formErrors={formErrors.dataset}
             />
             {isAdmin &&
                 <Button isLoading={uploadLoading} loadingText='Uploading' mt="10px" onClick={upload}>Submit</Button>


### PR DESCRIPTION
# Changes

* Created new reusable form components:
  - `CCTextInput`: for text inputs.
  - `CCSwitchInput`: for boolean switches.
  - `CCSelectInput`: for selecting a single choice.
  - `CCMultiSelectInput`: for selecting multiple choices.
* Added admin form for Scan Reports on frontend.
  - Found at `/scanreports/<scanreport_id>/admin`.
  - Scan report admins can change various attributes of a scan report.
  - *Cannot* change files associated with the scan report.

# Screenshots

- Successfully update a scan report.
![Screenshot 2022-03-24 at 15 15 46](https://user-images.githubusercontent.com/25085487/159953185-f441133b-2d11-4c66-9348-ef9e5222072b.png)

- User is not an admin
![Screenshot 2022-03-24 at 16 45 06](https://user-images.githubusercontent.com/25085487/159967671-51f26982-f241-45cd-9f75-906bc6277bc3.png)

# Checks

**Important:** please complete these **before** merging.
- [X] Run migrations, if any.
- [X] Update `changelog.md`, including migration instructions if any.
- [X] Run unit tests.
