### PR TITLE
Feature/link to scanreport details

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,7 +39,7 @@ Please append a line to the changelog for each change made.
 * Removed ajax functions and replaced with react fetch requests
 * Added permissions to view and edit Scan Reports.
 * Added admin form for Datasets on frontend.
-  * Found at `/datasets/admin/<dataset_id>`.
+  * Found at `/datasets/<dataset_id>/details`.
 * Implemented editors and associated permissions to Datasets and Scan Reports.
   - Editors of Datasets cannot add or remove viewers, editors or admins. They cannot
   delete Datasets, either.

--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,8 @@ Please append a line to the changelog for each change made.
   - `CCMultiSelectInput`: for selecting multiple choices.
 * Added admin form for Scan Reports on frontend.
   - Found at `/scanreports/<scanreport_id>/details`.
+* Added link to scan report details page to scan report list page.
+* Added link to scan report details page to scan report tables page.
 
 ## v1.4.0 was released 02/02/22
 

--- a/react-client-app/src/components/ScanReportTbl.jsx
+++ b/react-client-app/src/components/ScanReportTbl.jsx
@@ -250,7 +250,7 @@ const ScanReportTbl = (props) => {
             <Link href="/scanreports/create/"><Button variant="blue" my="10px">New Scan Report</Button></Link>
             <HStack>
                 <Text style={{ fontWeight: "bold" }}>Applied Filters: </Text>
-                {[{ title: "Data Partner -", filter: datapartnerFilter }, { title: "Dataset -", filter: datasetFilter },{ title: "Name -", filter: nameFilter }, { title: "Added By -", filter: authorFilter }, { title: "Status -", filter: statusFilter }].map(filter => {
+                {[{ title: "Data Partner -", filter: datapartnerFilter }, { title: "Dataset -", filter: datasetFilter }, { title: "Name -", filter: nameFilter }, { title: "Added By -", filter: authorFilter }, { title: "Status -", filter: statusFilter }].map(filter => {
                     if (filter.filter == "All") {
                         return null
                     }
@@ -292,7 +292,7 @@ const ScanReportTbl = (props) => {
                                     <option key={index} value={item}>{item}</option>
                                 )}
                         </Select></Th>
-                        
+
                         <Th >
                             <Select minW="110px" style={{ fontWeight: "bold" }} variant="unstyled" value="Added by" readOnly onChange={(option) => setAuthorFilter(option.target.value)}>
                                 <option style={{ fontWeight: "bold" }} disabled>Added by</option>
@@ -303,6 +303,7 @@ const ScanReportTbl = (props) => {
                             </Select>
                         </Th>
                         <Th style={{ fontSize: "16px", textTransform: "none" }}>Date</Th>
+                        <Th></Th>
                         <Th></Th>
                         <Th><Select minW="110px" style={{ fontWeight: "bold" }} variant="unstyled" value="Status" readOnly onChange={(option) => setStatusFilter(option.target.value)}>
                             <option style={{ fontWeight: "bold" }} disabled>Status</option>
@@ -339,12 +340,15 @@ const ScanReportTbl = (props) => {
                             <Tr className={expanded ? "largeTbl" : "mediumTbl"} key={index}>
                                 <Td maxW={"100px"}><Link style={{ color: "#0000FF", }} href={"/tables/?search=" + item.id}>{item.id}</Link></Td>
                                 <Td maxW={"100px"}><Link style={{ color: "#0000FF", }} href={"/tables/?search=" + item.id}>{item.data_partner.name}</Link></Td>
-                                <Td maxW={"100px"}><Link style={{ color: "#0000FF", }} href={"/datasets/" + item.parent_dataset.id+ "/details"}>{item.parent_dataset.name}</Link></Td>
+                                <Td maxW={"100px"}><Link style={{ color: "#0000FF", }} href={"/datasets/" + item.parent_dataset.id + "/details"}>{item.parent_dataset.name}</Link></Td>
                                 <Td maxW={"100px"}><Link style={{ color: "#0000FF", }} href={"/tables/?search=" + item.id}>{item.dataset}</Link></Td>
                                 <Td>{item.author.username}</Td>
                                 <Td maxW={"200px"} minW={expanded ? "170px" : "180px"}>{item.created_at.displayString}</Td>
                                 <Td >
                                     <Link href={"/scanreports/" + item.id + "/mapping_rules/"}><Button variant="blue">Rules</Button></Link>
+                                </Td>
+                                <Td >
+                                    <Link href={"/scanreports/" + item.id + "/details"}><Button variant="blue">Details</Button></Link>
                                 </Td>
                                 <Td >
                                     {item.statusLoading == true ?

--- a/react-client-app/src/components/TablesTbl.jsx
+++ b/react-client-app/src/components/TablesTbl.jsx
@@ -130,7 +130,14 @@ const TablesTbl = () => {
                     }
                 </Tbody>
             </Table>
-            <Link href={"/scanreports/" + value + "/mapping_rules/"}><Button variant="blue" my="10px">Go to Rules</Button></Link>
+            <HStack>
+                <Link href={"/scanreports/" + value + "/mapping_rules/"}>
+                    <Button variant="blue" my="10px">Go to Rules</Button>
+                </Link>
+                <Link href={"/scanreports/" + value + "/details"}>
+                    <Button variant="blue" my="10px">View Details</Button>
+                </Link>
+            </HStack>
         </div>
     );
 }

--- a/react-client-app/src/components/TablesTbl.jsx
+++ b/react-client-app/src/components/TablesTbl.jsx
@@ -8,6 +8,7 @@ import {
     Td,
     TableCaption,
     Flex,
+    Spacer,
     Spinner,
     Link,
     Button,
@@ -96,11 +97,21 @@ const TablesTbl = () => {
     }
     return (
         <div >
-            <HStack my="10px">
-                <Button variant="green" onClick={download_scan_report}>Download Scan Report File</Button>
-                <Button variant="blue" isDisabled={window.hide_button} onClick={download_data_dictionary}>Download Data Dictionary File</Button>
-
-            </HStack>
+            <Flex my="10px">
+                <HStack>
+                    <Link href={"/scanreports/" + value + "/details"}>
+                        <Button variant="blue" my="10px">Scan Report Details</Button>
+                    </Link>
+                    <Link href={"/scanreports/" + value + "/mapping_rules/"}>
+                        <Button variant="blue" my="10px">Go to Rules</Button>
+                    </Link>
+                </HStack>
+                <Spacer />
+                <HStack>
+                    <Button variant="green" onClick={download_scan_report}>Download Scan Report File</Button>
+                    <Button variant="blue" isDisabled={window.hide_button} onClick={download_data_dictionary}>Download Data Dictionary File</Button>
+                </HStack>
+            </Flex>
 
             <Table variant="striped" colorScheme="greyBasic">
                 <TableCaption></TableCaption>
@@ -130,14 +141,6 @@ const TablesTbl = () => {
                     }
                 </Tbody>
             </Table>
-            <HStack>
-                <Link href={"/scanreports/" + value + "/mapping_rules/"}>
-                    <Button variant="blue" my="10px">Go to Rules</Button>
-                </Link>
-                <Link href={"/scanreports/" + value + "/details"}>
-                    <Button variant="blue" my="10px">View Details</Button>
-                </Link>
-            </HStack>
         </div>
     );
 }


### PR DESCRIPTION
# Changes

- Added link to scan report details page to scan report list page.
- Added link to scan report details page to scan report tables page.

# Screenshots

- Link on list page
<img width="1461" alt="Screenshot 2022-03-25 at 14 19 33" src="https://user-images.githubusercontent.com/25085487/160139207-cafac728-3338-4ecb-a50d-f5be5d722345.png">

- Link on tables page
<img width="1359" alt="Screenshot 2022-03-28 at 11 18 02" src="https://user-images.githubusercontent.com/25085487/160378016-a788e173-8f59-4839-a622-159df0e18eae.png">

# Checks

**Important:** please complete these **before** merging.
- [X] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [X] Run unit tests.
