### PR TITLE
Update black to use `master`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
          submodules: 'recursive'
          ref: ${{ github.ref }}
      - name: Blacken Python code
-       uses: jpetrucciani/black-check@21.12b0
+       uses: jpetrucciani/black-check@master
        with:
          path: '.'
          black_flags: '--safe --verbose --diff'


### PR DESCRIPTION
# Changes

This is not totally desirable long-term, as we would be better to use releases. But the latest release still uses black 21.12, which is now broken. I've set a watch on the `black-check` repo so will be notified when that emits a new release we can directly reference.

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
