### PR TITLE
do not inherit dataset visibility

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1237,11 +1237,9 @@ class ScanReportFormView(FormView):
         dt = "{:%Y%m%d-%H%M%S}".format(datetime.datetime.now())
         print(dt, rand)
         # Create an entry in ScanReport for the uploaded Scan Report
-        parent_dataset = form.cleaned_data["parent_dataset"]
         scan_report = ScanReport.objects.create(
             dataset=form.cleaned_data["dataset"],
-            parent_dataset=parent_dataset,
-            visibility=parent_dataset.visibility,
+            parent_dataset=form.cleaned_data["parent_dataset"],
             name=modify_filename(form.cleaned_data.get("scan_report_file"), dt, rand),
         )
 

--- a/changelog.md
+++ b/changelog.md
@@ -60,8 +60,6 @@ Please append a line to the changelog for each change made.
 * Added link to scan report details page to scan report tables page.
 * Added Datasets content page which displays all the scanreports in a given dataset
 * Change the dataset link to go to the dataset content page
-* Changed Scan Report upload procedure.
-  - Scan Report inherits visibility from parent Dataset at upload.
 * Public Scan Reports under restricted Datasets are only visible to those
 with visibility of the Dataset.
 * Added Datasets content page which displays all the scanreports in a given dataset


### PR DESCRIPTION
# Changes

* Visibility not inherited from parent dataset. Default always to `PUBLIC`.
# Migrations
# Screenshots
# Checks

**Important:** please complete these **before** merging.
- [X] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [X] Run unit tests.
