### PR TITLE
Reformat django admin pages

### DIFF
--- a/api/mapping/admin.py
+++ b/api/mapping/admin.py
@@ -40,10 +40,12 @@ class ScanReportAdmin(admin.ModelAdmin):
 
     def get_name(self, obj):
         return obj.dataset
+
     get_name.short_description = "Scan Report Name"
 
     def get_parent_dataset(self, obj):
         return "%s: %s" % (obj.parent_dataset.id, obj.parent_dataset.name)
+
     get_parent_dataset.short_description = "Parent Dataset"
 
 
@@ -70,12 +72,7 @@ class ScanReportTableAdmin(admin.ModelAdmin):
 
 
 class ScanReportFieldAdmin(admin.ModelAdmin):
-    list_display = (
-        "id",
-        "get_name",
-        "get_scan_report_table",
-        "get_scan_report"
-    )
+    list_display = ("id", "get_name", "get_scan_report_table", "get_scan_report")
 
     def get_name(self, obj):
         return obj.name
@@ -88,8 +85,10 @@ class ScanReportFieldAdmin(admin.ModelAdmin):
     get_scan_report_table.short_description = "Scan Report Table"
 
     def get_scan_report(self, obj):
-        return "%s: %s" % (obj.scan_report_table.scan_report.id,
-                           obj.scan_report_table.scan_report.dataset)
+        return "%s: %s" % (
+            obj.scan_report_table.scan_report.id,
+            obj.scan_report_table.scan_report.dataset,
+        )
 
     get_scan_report.short_description = "Scan Report"
 
@@ -104,10 +103,12 @@ class ScanReportValueAdmin(admin.ModelAdmin):
 
     def get_name(self, obj):
         return obj.value
+
     get_name.short_description = "Value"
 
     def get_field(self, obj):
         return "%s: %s" % (obj.scan_report_field.id, obj.scan_report_field.name)
+
     get_field.short_description = "Scan Report Field"
 
 
@@ -128,12 +129,16 @@ class MappingRuleAdmin(admin.ModelAdmin):
     )
 
     def get_concept(self, obj):
-        return "%s: %s" % (obj.concept.concept.concept_id,
-                           obj.concept.concept.concept_name)
+        return "%s: %s" % (
+            obj.concept.concept.concept_id,
+            obj.concept.concept.concept_name,
+        )
+
     get_concept.short_description = "OMOP Concept"
 
     def get_omop_field(self, obj):
         return "%s" % (obj.omop_field.field)
+
     get_omop_field.short_description = "OMOP Field"
 
 
@@ -160,6 +165,7 @@ class OmopFieldAdmin(admin.ModelAdmin):
 
     def get_table(self, obj):
         return "%s: %s" % (obj.table.id, obj.table.table)
+
     get_table.short_description = "OMOP Table"
 
 

--- a/api/mapping/admin.py
+++ b/api/mapping/admin.py
@@ -19,18 +19,69 @@ from .models import (
 )
 
 
+class ScanReportAdmin(admin.ModelAdmin):
+    raw_id_fields = ("data_dictionary",)
+    filter_horizontal = (
+        "viewers",
+        "editors",
+    )
+
+
+class ScanReportTableAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "person_id",
+        "date_event",
+    )
+
+
+class ScanReportValueAdmin(admin.ModelAdmin):
+    raw_id_fields = ("scan_report_field",)
+
+
+class MappingRuleAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "scan_report",
+        "omop_field",
+        "source_table",
+        "source_field",
+        "concept",
+    )
+
+
+class ScanReportConceptAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "concept",
+        "content_object",
+    )
+
+
+class DatasetAdmin(admin.ModelAdmin):
+    filter_horizontal = (
+        "viewers",
+        "admins",
+        "editors",
+    )
+
+
+class ProjectAdmin(admin.ModelAdmin):
+    filter_horizontal = (
+        "datasets",
+        "members",
+    )
+
+
 admin.site.register(DataPartner)
-admin.site.register(ScanReport)
-admin.site.register(ScanReportTable)
+admin.site.register(ScanReport, ScanReportAdmin)
+admin.site.register(ScanReportTable, ScanReportTableAdmin)
 admin.site.register(ScanReportField)
-admin.site.register(ScanReportValue)
+admin.site.register(ScanReportValue, ScanReportValueAdmin)
 admin.site.register(ScanReportAssertion)
 admin.site.register(ClassificationSystem)
 admin.site.register(OmopTable)
 admin.site.register(OmopField)
-admin.site.register(MappingRule)
+admin.site.register(MappingRule, MappingRuleAdmin)
 admin.site.register(DataDictionary)
 admin.site.register(NLPModel)
-admin.site.register(ScanReportConcept)
-admin.site.register(Dataset)
-admin.site.register(Project)
+admin.site.register(ScanReportConcept, ScanReportConceptAdmin)
+admin.site.register(Dataset, DatasetAdmin)
+admin.site.register(Project, ProjectAdmin)

--- a/api/mapping/admin.py
+++ b/api/mapping/admin.py
@@ -25,6 +25,19 @@ class ScanReportAdmin(admin.ModelAdmin):
         "viewers",
         "editors",
     )
+    list_display = (
+        "id",
+        "get_name",
+        "get_parent_dataset",
+    )
+
+    def get_name(self, obj):
+        return obj.dataset
+    get_name.short_description = "Scan Report Name"
+
+    def get_parent_dataset(self, obj):
+        return "%s: %s" % (obj.parent_dataset.id, obj.parent_dataset.name)
+    get_parent_dataset.short_description = "Parent Dataset"
 
 
 class ScanReportTableAdmin(admin.ModelAdmin):
@@ -67,6 +80,10 @@ class ProjectAdmin(admin.ModelAdmin):
     filter_horizontal = (
         "datasets",
         "members",
+    )
+    list_display = (
+        "name",
+        "id",
     )
 
 

--- a/api/mapping/admin.py
+++ b/api/mapping/admin.py
@@ -19,6 +19,13 @@ from .models import (
 )
 
 
+class DataPartnerAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+    )
+
+
 class ScanReportAdmin(admin.ModelAdmin):
     raw_id_fields = ("data_dictionary",)
     filter_horizontal = (
@@ -45,10 +52,63 @@ class ScanReportTableAdmin(admin.ModelAdmin):
         "person_id",
         "date_event",
     )
+    list_display = (
+        "id",
+        "get_name",
+        "get_scan_report",
+    )
+
+    def get_name(self, obj):
+        return obj.name
+
+    get_name.short_description = "Name"
+
+    def get_scan_report(self, obj):
+        return "%s: %s" % (obj.scan_report.id, obj.scan_report.dataset)
+
+    get_scan_report.short_description = "Scan Report"
+
+
+class ScanReportFieldAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "get_name",
+        "get_scan_report_table",
+        "get_scan_report"
+    )
+
+    def get_name(self, obj):
+        return obj.name
+
+    get_name.short_description = "Name"
+
+    def get_scan_report_table(self, obj):
+        return "%s: %s" % (obj.scan_report_table.id, obj.scan_report_table.name)
+
+    get_scan_report_table.short_description = "Scan Report Table"
+
+    def get_scan_report(self, obj):
+        return "%s: %s" % (obj.scan_report_table.scan_report.id,
+                           obj.scan_report_table.scan_report.dataset)
+
+    get_scan_report.short_description = "Scan Report"
 
 
 class ScanReportValueAdmin(admin.ModelAdmin):
     raw_id_fields = ("scan_report_field",)
+    list_display = (
+        "id",
+        "get_name",
+        "get_field",
+    )
+
+    def get_name(self, obj):
+        return obj.value
+    get_name.short_description = "Value"
+
+    def get_field(self, obj):
+        return "%s: %s" % (obj.scan_report_field.id, obj.scan_report_field.name)
+    get_field.short_description = "Scan Report Field"
 
 
 class MappingRuleAdmin(admin.ModelAdmin):
@@ -59,12 +119,59 @@ class MappingRuleAdmin(admin.ModelAdmin):
         "source_field",
         "concept",
     )
+    list_display = (
+        "id",
+        "concept",
+        "get_omop_field",
+        "get_concept",
+        "source_field",
+    )
+
+    def get_concept(self, obj):
+        return "%s: %s" % (obj.concept.concept.concept_id,
+                           obj.concept.concept.concept_name)
+    get_concept.short_description = "OMOP Concept"
+
+    def get_omop_field(self, obj):
+        return "%s" % (obj.omop_field.field)
+    get_omop_field.short_description = "OMOP Field"
+
+
+class DataDictionaryAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+    )
+
+
+class OmopTableAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "table",
+    )
+
+
+class OmopFieldAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "field",
+        "get_table",
+    )
+
+    def get_table(self, obj):
+        return "%s: %s" % (obj.table.id, obj.table.table)
+    get_table.short_description = "OMOP Table"
 
 
 class ScanReportConceptAdmin(admin.ModelAdmin):
     raw_id_fields = (
         "concept",
         "content_object",
+    )
+    list_display = (
+        "id",
+        "concept",
+        "object_id",
     )
 
 
@@ -73,6 +180,11 @@ class DatasetAdmin(admin.ModelAdmin):
         "viewers",
         "admins",
         "editors",
+    )
+    list_display = (
+        "id",
+        "name",
+        "visibility",
     )
 
 
@@ -87,17 +199,17 @@ class ProjectAdmin(admin.ModelAdmin):
     )
 
 
-admin.site.register(DataPartner)
+admin.site.register(DataPartner, DataPartnerAdmin)
 admin.site.register(ScanReport, ScanReportAdmin)
 admin.site.register(ScanReportTable, ScanReportTableAdmin)
-admin.site.register(ScanReportField)
+admin.site.register(ScanReportField, ScanReportFieldAdmin)
 admin.site.register(ScanReportValue, ScanReportValueAdmin)
 admin.site.register(ScanReportAssertion)
 admin.site.register(ClassificationSystem)
-admin.site.register(OmopTable)
-admin.site.register(OmopField)
+admin.site.register(OmopTable, OmopTableAdmin)
+admin.site.register(OmopField, OmopFieldAdmin)
 admin.site.register(MappingRule, MappingRuleAdmin)
-admin.site.register(DataDictionary)
+admin.site.register(DataDictionary, DataDictionaryAdmin)
 admin.site.register(NLPModel)
 admin.site.register(ScanReportConcept, ScanReportConceptAdmin)
 admin.site.register(Dataset, DatasetAdmin)

--- a/changelog.md
+++ b/changelog.md
@@ -71,6 +71,7 @@ with visibility of the Dataset.
   - Link to Dataset details page for each dataset
 * Remove unused ajax POST function.
 * Remove unused JS variables.
+* Improved django admin pages' responsiveness and informativeness
 
 ## v1.4.0 was released 02/02/22
 


### PR DESCRIPTION
# Changes

Made the django administration pages more responsive and more informative.
- More responsive through using `raw_id_field` on a number of `ForeignKey` and `ManyToMany` fields to stop all the possible objects being loaded for selection from dropdowns.
- More informative by displaying more columns on the changelist page of most classes: navigating is therefore easier because e.g. Projects are shown with their name rather than just their ID.
- Clearer selection of multiple users in the editor/admin/viewer fields by using the `filter_horizontal` option, and similarly when selecting datasets linked to a project.

# Migrations

None

# Screenshots
`raw_id_fields`:
![image](https://user-images.githubusercontent.com/11610738/161047880-38a32791-cead-4575-9481-c1f8d25ed8d1.png)

Changelist:
![image](https://user-images.githubusercontent.com/11610738/161047206-873aa18f-8891-47e8-b639-d2f411f80b69.png)

filter_horizontal:
![Screenshot 2022-03-31 at 12 44 02](https://user-images.githubusercontent.com/11610738/161047626-7c78886a-d601-4ed8-a67a-83b77c9d9b77.png)


# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
