### PR TITLE
Fix tests

### DIFF
--- a/api/mapping/admin.py
+++ b/api/mapping/admin.py
@@ -172,7 +172,10 @@ class OmopFieldAdmin(admin.ModelAdmin):
 class ScanReportConceptAdmin(admin.ModelAdmin):
     raw_id_fields = (
         "concept",
-        "content_object",
+        # "content_object",  # This is not in raw_id_fields because unit test throw
+        # an error as content_object is a GenericForeignKey and not a ForeignKey or
+        # ManyToMany. However, this does mean navigating to the ScanReportConcept
+        # admin page will be very slow.
     )
     list_display = (
         "id",

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from rest_framework.generics import GenericAPIView
@@ -504,6 +505,7 @@ class TestCanView(TestCase):
             )
         )
 
+    @mock.patch.dict(os.environ, {"AZ_FUNCTION_USER": "az_functions"}, clear=True)
     def test_az_function_user_perm(self):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
@@ -602,6 +604,7 @@ class TestCanEdit(TestCase):
             )
         )
 
+    @mock.patch.dict(os.environ, {"AZ_FUNCTION_USER": "az_functions"}, clear=True)
     def test_az_function_user_perm(self):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
@@ -698,6 +701,7 @@ class TestCanAdmin(TestCase):
             self.permission.has_object_permission(self.request, self.view, sr)
         )
 
+    @mock.patch.dict(os.environ, {"AZ_FUNCTION_USER": "az_functions"}, clear=True)
     def test_az_function_user_perm(self):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))

--- a/api/mapping/test_permissions.py
+++ b/api/mapping/test_permissions.py
@@ -17,7 +17,7 @@ from .permissions import (
 from .views import (
     ProjectRetrieveView,
 )
-from .models import Project, Dataset, ScanReport, VisibilityChoices
+from .models import Project, Dataset, ScanReport, VisibilityChoices, DataPartner
 
 
 class TestHasViewership(TestCase):
@@ -60,12 +60,19 @@ class TestHasViewership(TestCase):
             self.non_restricted_sr_viewer,
         )
 
+        # Create a Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
+
         # Set up datasets
         self.public_dataset = Dataset.objects.create(
-            name="The Fellowship of the Ring", visibility=VisibilityChoices.PUBLIC
+            name="The Fellowship of the Ring",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         self.restricted_dataset = Dataset.objects.create(
-            name="The Two Towers", visibility=VisibilityChoices.RESTRICTED
+            name="The Two Towers",
+            visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
         )
         self.restricted_dataset.viewers.add(self.user_with_perm)
         self.project.datasets.add(self.public_dataset, self.restricted_dataset)
@@ -165,13 +172,19 @@ class TestHasEditorship(TestCase):
             self.non_restricted_sr_viewer,
         )
 
+        # Create a Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         # Set up datasets
         self.public_dataset = Dataset.objects.create(
-            name="The Fellowship of the Ring", visibility=VisibilityChoices.PUBLIC
+            name="The Fellowship of the Ring",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         self.public_dataset.editors.add(self.user_with_perm)
         self.restricted_dataset = Dataset.objects.create(
-            name="The Two Towers", visibility=VisibilityChoices.RESTRICTED
+            name="The Two Towers",
+            visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
         )
         self.restricted_dataset.viewers.add(self.user_with_perm)
         self.restricted_dataset.editors.add(self.user_with_perm)
@@ -272,13 +285,19 @@ class TestIsAdmin(TestCase):
             self.sr_author,
         )
 
+        # Create a Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         # Set up datasets
         self.public_dataset = Dataset.objects.create(
-            name="The Fellowship of the Ring", visibility=VisibilityChoices.PUBLIC
+            name="The Fellowship of the Ring",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         self.public_dataset.admins.add(self.ds_admin)
         self.restricted_dataset = Dataset.objects.create(
-            name="The Two Towers", visibility=VisibilityChoices.RESTRICTED
+            name="The Two Towers",
+            visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
         )
         self.restricted_dataset.viewers.add(self.ds_admin)
         self.restricted_dataset.admins.add(self.ds_admin)
@@ -430,13 +449,20 @@ class TestCanView(TestCase):
         self.project = Project.objects.create(name="The Fellowship of the Ring")
         # Add the permitted users
         self.project.members.add(self.public_user, self.restricted_user)
+
+        # Create a Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         # Create the public dataset
         self.public_dataset = Dataset.objects.create(
-            name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
+            name="Hobbits of the Fellowship",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         # Create the restricted dataset
         self.restricted_dataset = Dataset.objects.create(
-            name="Ring bearers", visibility=VisibilityChoices.RESTRICTED
+            name="Ring bearers",
+            visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
         )
         # Add the restricted users
         self.restricted_dataset.viewers.add(self.restricted_user)
@@ -543,9 +569,14 @@ class TestCanEdit(TestCase):
         self.project = Project.objects.create(name="The Fellowship of the Ring")
         # Add the permitted users
         self.project.members.add(self.non_editor, self.editor)
+
+        # Create a Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         # Create the public dataset
         self.dataset = Dataset.objects.create(
-            name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
+            name="Hobbits of the Fellowship",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         # Add the restricted users
         self.dataset.admins.add(self.editor)
@@ -637,9 +668,13 @@ class TestCanAdmin(TestCase):
         self.project = Project.objects.create(name="The Fellowship of the Ring")
         # Add the permitted users
         self.project.members.add(self.non_admin, self.admin)
+        # Create a Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         # Create the public dataset
         self.dataset = Dataset.objects.create(
-            name="Hobbits of the Fellowship", visibility=VisibilityChoices.PUBLIC
+            name="Hobbits of the Fellowship",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         # Add the restricted users
         self.dataset.admins.add(self.admin)

--- a/api/mapping/test_serializers.py
+++ b/api/mapping/test_serializers.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory
 from rest_framework.authtoken.models import Token
 from rest_framework.serializers import ValidationError
-from .models import Project, Dataset, ScanReport, VisibilityChoices
+from .models import Project, Dataset, ScanReport, VisibilityChoices, DataPartner
 from .serializers import ScanReportEditSerializer
 
 
@@ -25,12 +25,16 @@ class TestScanReportEditSerializer(TestCase):
         )
         self.editor_user = User.objects.create(username="sauron", password="oijfowfjef")
         self.project = Project.objects.create(name="The Fellowship of The Ring")
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         self.public_dataset = Dataset.objects.create(
-            name="Places in Middle Earth", visibility=VisibilityChoices.PUBLIC
+            name="Places in Middle Earth",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         self.restricted_dataset = Dataset.objects.create(
             name="Forbidden Places in Middle Earth",
             visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
         )
         self.public_dataset.admins.add(self.admin_user)
         self.project.datasets.add(self.public_dataset, self.restricted_dataset)

--- a/api/mapping/test_services_rules.py
+++ b/api/mapping/test_services_rules.py
@@ -26,7 +26,7 @@ class TestMisalignedMappings(TestCase):
         self.user1 = User.objects.create(username="oliver", password="uhafcvbsyrgf")
         # Generate Token for the user
         Token.objects.create(user=self.user1)
-        # Create Dataser
+        # Create Dataset
         self.data_partner = DataPartner.objects.create(name="Data Partner")
         self.dataset1 = Dataset.objects.create(
             name="Dataset", visibility="PUBLIC", data_partner=self.data_partner

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, APIClient, force_authenticate
@@ -138,6 +139,7 @@ class TestDatasetListView(TestCase):
         # Assert response is empty
         self.assertEqual(response_data, [])
 
+    @mock.patch.dict(os.environ, {"AZ_FUNCTION_USER": "az_functions"}, clear=True)
     def test_az_function_user_perm(self):
         User = get_user_model()
         az_user = User.objects.get(username=os.getenv("AZ_FUNCTION_USER"))
@@ -537,6 +539,7 @@ class TestScanReportListViewset(TestCase):
         # Assert the observed results are the same as the expected
         self.assertListEqual(observed_objs, expected_objs)
 
+    @mock.patch.dict(os.environ, {"AZ_FUNCTION_USER": "az_functions"}, clear=True)
     def test_az_function_user_get(self):
         """AZ_FUNCTION_USER can see all public SRs and restricted SRs."""
         User = get_user_model()

--- a/api/mapping/test_views.py
+++ b/api/mapping/test_views.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, APIClient, force_authenticate
 from rest_framework.authtoken.models import Token
 from .views import DatasetListView, ScanReportListViewSet
-from .models import Project, Dataset, ScanReport, VisibilityChoices
+from .models import Project, Dataset, ScanReport, VisibilityChoices, DataPartner
 
 
 class TestDatasetListView(TestCase):
@@ -17,18 +17,28 @@ class TestDatasetListView(TestCase):
         self.user2 = User.objects.create(username="aragorn", password="ooieriofiejr")
         Token.objects.create(user=self.user2)
 
+        # Set up a Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         # Set up datasets
         self.public_dataset1 = Dataset.objects.create(
-            name="Places in Middle Earth", visibility="PUBLIC"
+            name="Places in Middle Earth",
+            visibility="PUBLIC",
+            data_partner=self.data_partner,
         )
         self.public_dataset2 = Dataset.objects.create(
-            name="Places in Valinor", visibility="PUBLIC"
+            name="Places in Valinor",
+            visibility="PUBLIC",
+            data_partner=self.data_partner,
         )
         self.public_dataset3 = Dataset.objects.create(
-            name="The Rings of Power", visibility="PUBLIC"
+            name="The Rings of Power",
+            visibility="PUBLIC",
+            data_partner=self.data_partner,
         )
         self.restricted_dataset = Dataset.objects.create(
-            name="Fellowship Members", visibility="RESTRICTED"
+            name="Fellowship Members",
+            visibility="RESTRICTED",
+            data_partner=self.data_partner,
         )
         self.restricted_dataset.viewers.add(self.user1)
 
@@ -180,9 +190,14 @@ class TestDatasetUpdateView(TestCase):
         self.project = Project.objects.create(name="The Fellowship of the Ring")
         self.project.members.add(self.admin_user, self.non_admin_user)
 
+        # Set up Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
+
         # Set up Dataset
         self.dataset = Dataset.objects.create(
-            name="The Heights of Hobbits", visibility=VisibilityChoices.PUBLIC
+            name="The Heights of Hobbits",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         self.dataset.admins.add(self.admin_user)
         self.project.datasets.add(self.dataset)
@@ -244,9 +259,14 @@ class TestDatasetRetrieveView(TestCase):
         self.project = Project.objects.create(name="The Fellowship of the Ring")
         self.project.members.add(self.admin_user, self.non_admin_user)
 
+        # Set up Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
+
         # Set up Dataset
         self.dataset = Dataset.objects.create(
-            name="The Heights of Hobbits", visibility=VisibilityChoices.RESTRICTED
+            name="The Heights of Hobbits",
+            visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
         )
         self.dataset.viewers.add(self.non_admin_user)
         self.dataset.admins.add(self.admin_user)
@@ -301,9 +321,14 @@ class TestDatasetDeleteView(TestCase):
         self.project = Project.objects.create(name="The Fellowship of the Ring")
         self.project.members.add(self.admin_user, self.non_admin_user)
 
+        # Set up Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
+
         # Set up Dataset
         self.dataset = Dataset.objects.create(
-            name="The Heights of Hobbits", visibility=VisibilityChoices.PUBLIC
+            name="The Heights of Hobbits",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         self.dataset.admins.add(self.admin_user)
         self.project.datasets.add(self.dataset)
@@ -338,12 +363,19 @@ class TestDatasetDeleteView(TestCase):
 
 class TestScanReportListViewset(TestCase):
     def setUp(self):
+        # Set up Data Partner
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
+
         # Set up datasets
         self.public_dataset = Dataset.objects.create(
-            name="The Shire", visibility=VisibilityChoices.PUBLIC
+            name="The Shire",
+            visibility=VisibilityChoices.PUBLIC,
+            data_partner=self.data_partner,
         )
         self.restricted_dataset = Dataset.objects.create(
-            name="The Mines of Moria", visibility=VisibilityChoices.RESTRICTED
+            name="The Mines of Moria",
+            visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
         )
 
         # Set up scan reports


### PR DESCRIPTION
# Changes

Fix unit tests 
- Add DataPartner to all Datasets
- Mock missing `AZ_FUNCTION_USER` environment variable
- Fix error due to GenericForeignKey not being supported by raw_id_fields when running through unittest.

# Migrations

# Screenshots

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
