### PR TITLE
Bugfix/non editors can edit concepts

### DIFF
--- a/api/mapping/templates/mapping/scanreportfield_list.html
+++ b/api/mapping/templates/mapping/scanreportfield_list.html
@@ -22,6 +22,7 @@
     <div id='root'></div>
     <script type="text/javascript" >
         var pk = "{{pk}}";
+        var canEdit = "{{can_edit}}" === "True" ? true : false;
     </script>
     <script type="module" src="../../../static/javascript/react/src/fieldsTable.js"></script>
     

--- a/api/mapping/templates/mapping/scanreporttable_list.html
+++ b/api/mapping/templates/mapping/scanreporttable_list.html
@@ -20,6 +20,7 @@
         var scan_report="{{scan_report}}";
         var scan_report_name="{{scan_report_name}}";
         var data_dictionary="{{data_dictionary}}";
+        var canEdit = "{{can_edit}}" === "True" ? true : false;
         var hide_button=false;
         if (!data_dictionary){
             hide_button=true;

--- a/api/mapping/templates/mapping/scanreportvalue_list.html
+++ b/api/mapping/templates/mapping/scanreportvalue_list.html
@@ -25,6 +25,7 @@
     <div id='root'></div>
     <script type="text/javascript" >
         var pk ="{{pk}}"
+        var canEdit = "{{can_edit}}" === "True" ? true : false;
         var s = document.createElement("script");
         s.type = "module";
 		s.innerHTML = null;

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1989,6 +1989,9 @@ def scanreport_values_list_page(request, sr, tbl, pk):
         args["scan_report"] = scan_report
         args["scan_report_field"] = scan_report_field
         args["scan_report_table"] = scan_report_table
+        args["can_edit"] = has_editorship(scan_report_field, request) or is_admin(
+            scan_report_field, request
+        )
 
         return render(request, "mapping/scanreportvalue_list.html", args)
     except ObjectDoesNotExist:

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1948,6 +1948,9 @@ def scanreport_table_list_page(request, pk):
 
         args["scan_report"] = scan_report
         args["scan_report_name"] = scan_report_name
+        args["can_edit"] = has_editorship(scan_report, request) or is_admin(
+            scan_report, request
+        )
 
         return render(request, "mapping/scanreporttable_list.html", args)
     except ObjectDoesNotExist:

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -120,6 +120,8 @@ from .permissions import (
     CanView,
     CanAdmin,
     CanEdit,
+    has_editorship,
+    is_admin,
 )
 from .services import download_data_dictionary_blob
 
@@ -1963,6 +1965,9 @@ def scanreport_fields_list_page(request, sr, pk):
         args["pk"] = pk
         args["scan_report"] = scan_report_table.scan_report
         args["scan_report_table"] = scan_report_table
+        args["can_edit"] = has_editorship(scan_report_table, request) or is_admin(
+            scan_report_table, request
+        )
 
         return render(request, "mapping/scanreportfield_list.html", args)
     except ObjectDoesNotExist:

--- a/changelog.md
+++ b/changelog.md
@@ -85,6 +85,7 @@ Please append a line to the changelog for each change made.
 * Created Error 404 page.
 * Added Archive/Active functionality to Dataset page
   - Created new field 'hidden' in Dataset table
+* Users without editor or admin permissions on a scan report will not longer see an option to edit the tables, fields, values or concepts.
 
 ## v1.4.0 was released 02/02/22
 

--- a/react-client-app/src/components/FieldsTbl.jsx
+++ b/react-client-app/src/components/FieldsTbl.jsx
@@ -122,7 +122,7 @@ const FieldsTbl = (props) => {
                             <Th>Data type</Th>
                             <Th>Concepts</Th>
                             <Th></Th>
-                            <Th>Edit</Th>
+                            {window.canEdit && <Th>Edit</Th>}
                         </Tr>
                     </Thead>
                     <Tbody>
@@ -139,8 +139,15 @@ const FieldsTbl = (props) => {
                                             item.concepts.length > 0 &&
                                             <VStack alignItems='flex-start' >
                                                 {item.concepts.map((concept) => (
-                                                    <ConceptTag key={concept.concept.concept_id} conceptName={concept.concept.concept_name} conceptId={concept.concept.concept_id.toString()} conceptIdentifier={concept.id.toString()} itemId={item.id} handleDelete={handleDelete}
-                                                        creation_type={concept.creation_type ? concept.creation_type : undefined} />
+                                                    <ConceptTag
+                                                        key={concept.concept.concept_id}
+                                                        conceptName={concept.concept.concept_name}
+                                                        conceptId={concept.concept.concept_id.toString()}
+                                                        conceptIdentifier={concept.id.toString()} itemId={item.id}
+                                                        handleDelete={handleDelete}
+                                                        creation_type={concept.creation_type ? concept.creation_type : undefined}
+                                                        readOnly={!window.canEdit}
+                                                    />
                                                 ))}
                                             </VStack>
                                             :
@@ -168,16 +175,18 @@ const FieldsTbl = (props) => {
                                                             name='concept'
                                                             value={values.concept}
                                                             onChange={handleChange}
-                                                            onBlur={handleBlur} />
+                                                            onBlur={handleBlur}
+                                                            isDisabled={!window.canEdit}
+                                                        />
                                                         <div>
-                                                            <Button type='submit' disabled={false} backgroundColor='#3C579E' color='white'>Add</Button>
+                                                            <Button type='submit' isDisabled={!window.canEdit} backgroundColor='#3C579E' color='white'>Add</Button>
                                                         </div>
                                                     </HStack>
                                                 </Form>
                                             )}
                                         </Formik>
                                     </Td>
-                                    <Td><Link style={{ color: "#0000FF", }} href={"/fields/" + item.id + "/update/"}>Edit Field</Link></Td>
+                                    {window.canEdit && <Td><Link style={{ color: "#0000FF", }} href={"/fields/" + item.id + "/update/"}>Edit Field</Link></Td>}
                                 </Tr>
                             )
                         }

--- a/react-client-app/src/components/TablesTbl.jsx
+++ b/react-client-app/src/components/TablesTbl.jsx
@@ -143,7 +143,7 @@ const TablesTbl = () => {
                         <Th>Name</Th>
                         <Th>Person ID</Th>
                         <Th>Event Date</Th>
-                        <Th>Edit</Th>
+                        {window.canEdit && <Th>Edit</Th>}
                     </Tr>
                 </Thead>
                 <Tbody>
@@ -153,7 +153,7 @@ const TablesTbl = () => {
                                 <Td maxW={"200px"}><Link style={{ color: "#0000FF", }} href={`/scanreports/${scanReportId}/tables/${item.id}`}>{item.name}</Link></Td>
                                 <Td maxW={"200px"}>{item.person_id ? item.person_id.name : null} </Td>
                                 <Td maxW={"200px"}>{item.date_event ? item.date_event.name : null}</Td>
-                                <Td maxW={"200px"}><Link style={{ color: "#0000FF", }} href={"/tables/" + item.id + "/update/"}>Edit Table</Link></Td>
+                                {window.canEdit && <Td maxW={"200px"}><Link style={{ color: "#0000FF", }} href={"/tables/" + item.id + "/update/"}>Edit Table</Link></Td>}
                             </Tr>
 
                         )

--- a/react-client-app/src/components/ValuesTbl.jsx
+++ b/react-client-app/src/components/ValuesTbl.jsx
@@ -134,8 +134,15 @@ const ValuesTbl = (props) => {
                                             item.concepts.length > 0 &&
                                             <VStack alignItems='flex-start' >
                                                 {item.concepts.map((concept) => (
-                                                    <ConceptTag key={concept.concept.concept_id} conceptName={concept.concept.concept_name} conceptId={concept.concept.concept_id.toString()} conceptIdentifier={concept.id.toString()} itemId={item.id} handleDelete={handleDelete}
-                                                        creation_type={concept.creation_type ? concept.creation_type : undefined} />
+                                                    <ConceptTag
+                                                        key={concept.concept.concept_id}
+                                                        conceptName={concept.concept.concept_name}
+                                                        conceptId={concept.concept.concept_id.toString()}
+                                                        conceptIdentifier={concept.id.toString()}
+                                                        itemId={item.id} handleDelete={handleDelete}
+                                                        creation_type={concept.creation_type ? concept.creation_type : undefined}
+                                                        readOnly={!window.canEdit}
+                                                    />
                                                 ))}
                                             </VStack>
                                             :
@@ -163,9 +170,11 @@ const ValuesTbl = (props) => {
                                                             name='concept'
                                                             value={values.concept}
                                                             onChange={handleChange}
-                                                            onBlur={handleBlur} />
+                                                            onBlur={handleBlur}
+                                                            isDisabled={!window.canEdit}
+                                                        />
                                                         <div>
-                                                            <Button type='submit' disabled={!item.conceptsToLoad == 0} backgroundColor='#3C579E' color='white'>Add</Button>
+                                                            <Button type='submit' isDisabled={!((item.conceptsToLoad == 0) || window.canEdit)} backgroundColor='#3C579E' color='white'>Add</Button>
                                                         </div>
                                                     </HStack>
                                                 </Form>


### PR DESCRIPTION
# Changes

* Users without editor or admin permissions on a scan report will not longer see an option to edit the tables, fields, values or concepts.

# Migrations
# Screenshots
# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [X] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
