### PR TITLE
Bugfix/non viewers can see details pages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -87,6 +87,7 @@ Please append a line to the changelog for each change made.
   - Created new field 'hidden' in Dataset table
 * Users without editor or admin permissions on a scan report will not longer see an option to edit the tables, fields, values or concepts.
 * Users without editor or admin permissions on an uploaded scan report's selected parent dataset cannot upload the scan report to that dataset.
+* User will see a generic error message when they navigate to a dataset or scan report detail/admin page which they do not have permission to view (or it does not exist).
 
 ## v1.4.0 was released 02/02/22
 


### PR DESCRIPTION
# Changes
- User will see a generic error message when they navigate to a dataset or scan report detail/admin page which they do not have permission to view (or it does not exist).
# Migrations
# Screenshots
# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
