### PR TITLE
bug fix of dataset page not loading

### DIFF
--- a/react-client-app/src/views/DatasetsContent.jsx
+++ b/react-client-app/src/views/DatasetsContent.jsx
@@ -74,9 +74,11 @@ const DatasetsContent = (props) => {
         }
         let dataPartners = await Promise.all(dataPartnerPromises)
         dataPartners = dataPartners[0]
-        dataPartners.forEach((element) => {
-            scanreports = scanreports.map((scanreport) => scanreport.parent_dataset.data_partner === element.id ? { ...scanreport, data_partner: element } : scanreport);
-        });
+        if(dataPartners){
+            dataPartners.forEach((element) => {
+                scanreports = scanreports.map((scanreport) => scanreport.parent_dataset.data_partner === element.id ? { ...scanreport, data_partner: element } : scanreport);
+            });
+        }
         // split data into active reports and archived report
         data.current = scanreports
         activeReports.current = scanreports.filter(scanreport => scanreport.hidden === false)


### PR DESCRIPTION
# Changes

- Fixed bug where dataset page wouldn't load when there were no scanreports associated to them

# Migrations


# Screenshots

- Used to result in permanent
<img width="749" alt="image" src="https://user-images.githubusercontent.com/38753056/164712316-a514ddeb-eb38-43df-afdb-17bf2342ff76.png">

- Now shows
<img width="229" alt="image" src="https://user-images.githubusercontent.com/38753056/164712421-bd61bbad-201c-44ee-b54b-8f50d0164c43.png">


# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
