### PR TITLE
added check to stop duplicate concepts

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -599,7 +599,18 @@ class ScanReportConceptViewSet(viewsets.ModelViewSet):
         )
         if concept.count() > 0:
             print("Can't add multiple concepts of the same id to the same object")
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+            response = JsonResponse(
+                {
+                    "status_code": 400,
+                    "ok": False,
+                    "statusText": "Can't add multiple concepts of the same id to the same object",
+                }
+            )
+            response.status_code = 400
+            response.statusText = (
+                "Can't add multiple concepts of the same id to the same object"
+            )
+            return response
 
         serializer = self.get_serializer(
             data=request.data, many=isinstance(request.data, list)

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -607,9 +607,6 @@ class ScanReportConceptViewSet(viewsets.ModelViewSet):
                 }
             )
             response.status_code = 400
-            response.statusText = (
-                "Can't add multiple concepts of the same id to the same object"
-            )
             return response
 
         serializer = self.get_serializer(

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -591,6 +591,16 @@ class ScanReportConceptViewSet(viewsets.ModelViewSet):
     serializer_class = ScanReportConceptSerializer
 
     def create(self, request, *args, **kwargs):
+        body = request.data
+        concept = ScanReportConcept.objects.filter(
+            concept=body["concept"],
+            object_id=body["object_id"],
+            content_type=body["content_type"],
+        )
+        if concept.count() > 0:
+            print("Can't add multiple concepts of the same id to the same object")
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
         serializer = self.get_serializer(
             data=request.data, many=isinstance(request.data, list)
         )

--- a/react-client-app/src/App.jsx
+++ b/react-client-app/src/App.jsx
@@ -220,15 +220,18 @@ const App = ({ page }) => {
                             // if an error occurs while trying to add the concept, return to original state
                             valuesRef.current = valuesRef.current.map((value) => value.id == id ? { ...value, conceptsLoaded: true } : value)
                             setValues(valuesRef.current)
-
-                            if (typeof (error) !== 'undefined' && error.response != null) {
-                                setAlert({
-                                    status: 'error',
-                                    title: 'Unable to link Concept id to value',
-                                    description: 'Response: ' + error.response.status + ' ' + error.response.statusText
-                                })
-                                onOpen()
-
+                            let description = "Response: " + error.response.status + " " + error.response.statusText
+                            if(error.response&& error.response.data){
+                              const body = error.response.data
+                              description = "Response: " + body.status_code + " " + body.statusText
+                            }
+                            if (typeof error !== "undefined" && error.response != null) {
+                              setAlert({
+                                status: "error",
+                                title: "Unable to link Concept id to value",
+                                description: description
+                              });
+                              onOpen();
                             }
                         })
 


### PR DESCRIPTION
# Changes
- Added check on backend to make sure user can't add multiple concepts to the same object

# Migrations


# Screenshots
- This is now shown when user tries to add a duplicate concept
<img width="921" alt="image" src="https://user-images.githubusercontent.com/38753056/165277701-956a6763-2dde-49e4-91b8-7fcf4d06683c.png">

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
