### PR TITLE
Replace old urls

### DIFF
--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -869,6 +869,7 @@ def get_concept_details(h_concept_id):
             "source_field__name",
             "source_field__scan_report_table__id",
             "source_field__scan_report_table__name",
+            "source_field__scan_report_table__scan_report",
             "concept__content_type",
         )
     ).distinct()

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -189,11 +189,6 @@ urlpatterns = [
     path("api_auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("", views.home, name="home"),
     path("tables/", views.ScanReportTableListView.as_view(), name="tables"),
-    path(
-        "tables/<int:pk>/update/",
-        views.update_scanreport_table_page,
-        name="scan-report-table-update",
-    ),
     path("fields/", views.ScanReportFieldListView.as_view(), name="fields"),
     path(
         "fields/<int:pk>/update/",
@@ -314,7 +309,7 @@ urlpatterns = [
     ),
     path(
         "scanreports/<int:sr>/tables/<int:pk>/update",
-        views.update_scanreport_table_page2,
+        views.update_scanreport_table_page,
         name="scan-report-table-update",
     ),
     path(

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -190,11 +190,6 @@ urlpatterns = [
     path("", views.home, name="home"),
     path("tables/", views.ScanReportTableListView.as_view(), name="tables"),
     path("fields/", views.ScanReportFieldListView.as_view(), name="fields"),
-    path(
-        "fields/<int:pk>/update/",
-        views.ScanReportFieldUpdateView.as_view(),
-        name="scan-report-field-update",
-    ),
     path("values/", views.ScanReportValueListView.as_view(), name="values"),
     path("scanreports/", views.ScanReportListView.as_view(), name="scan-report-list"),
     path(

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1011,22 +1011,6 @@ class ScanReportFieldListView(ListView):
 
 
 @method_decorator(login_required, name="dispatch")
-class ScanReportFieldUpdateView(UpdateView):
-    model = ScanReportField
-    form_class = ScanReportFieldForm
-    template_name = "mapping/scanreportfield_form.html"
-
-    def get_success_url(self):
-        return "{}?search={}".format(
-            reverse("fields"), self.object.scan_report_table.id
-        )
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        return context
-
-
-@method_decorator(login_required, name="dispatch")
 class ScanReportStructuralMappingUpdateView(UpdateView):
     model = ScanReportField
     fields = ["mapping"]

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -950,56 +950,8 @@ class ScanReportTableListView(ListView):
         return context
 
 
-@method_decorator(login_required, name="dispatch")
-class ScanReportTableUpdateView(UpdateView):
-    model = ScanReportTable
-    fields = ["person_id", "date_event"]
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        # filter so the objects can only be associated to the current scanreport table
-        scan_report_table = context["scanreporttable"]
-        qs = ScanReportField.objects.filter(
-            scan_report_table=scan_report_table
-        ).order_by("name")
-
-        for key in context["form"].fields.keys():
-            context["form"].fields[key].queryset = qs
-
-            def label_from_instance(obj):
-                return obj.name
-
-            context["form"].fields[key].label_from_instance = label_from_instance
-        return context
-
-    def get_success_url(self):
-        return "{}?search={}".format(reverse("tables"), self.object.scan_report.id)
-
-
 @login_required
-def update_scanreport_table_page(request, pk):
-    # Get the SR table
-    sr_table = ScanReportTable.objects.get(id=pk)
-    # Determine if the user can edit the form
-    can_edit = False
-    if (
-        sr_table.scan_report.author.id == request.user.id
-        or sr_table.scan_report.editors.filter(id=request.user.id).exists()
-        or sr_table.scan_report.parent_dataset.editors.filter(
-            id=request.user.id
-        ).exists()
-        or sr_table.scan_report.parent_dataset.admins.filter(
-            id=request.user.id
-        ).exists()
-    ):
-        can_edit = True
-    # Set the page context
-    context = {"object": sr_table, "can_edit": can_edit}
-    return render(request, "mapping/scanreporttable_form.html", context=context)
-
-
-@login_required
-def update_scanreport_table_page2(request, sr, pk):
+def update_scanreport_table_page(request, sr, pk):
     # Get the SR table
     sr_table = ScanReportTable.objects.get(id=pk)
     # Determine if the user can edit the form

--- a/react-client-app/src/components/AnalysisTbl.jsx
+++ b/react-client-app/src/components/AnalysisTbl.jsx
@@ -14,7 +14,7 @@ function AnalysisTbl({ data }) {
     return (
         <Grid templateColumns="repeat(4, 1fr)" gap={6} >
 
-            <Text fontWeight={"bold"}>Rule ID</Text>
+            <Text fontWeight={"bold"}>Concept ID</Text>
             <Text fontWeight={"bold"}>
                 <span style={{ color: "#475da7" }}>Ancestors</span> /
                 <span style={{ color: "#3db28c" }}> Descendants</span>
@@ -40,8 +40,8 @@ function AnalysisTbl({ data }) {
                                                         {ancestor.source.map(source_id => {
 
                                                             if (source_id.concept__content_type == 15)
-                                                                return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={"/fields/?search=" + source_id.source_field__scan_report_table__id}> {truncate(source_id.source_field__name)} </Link> </Text>
-                                                            return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}> <Link style={{ color: "#0000FF" }} href={"/values/?search=" + source_id.source_field__id}> {truncate(source_id.source_field__name)} </Link></Text>
+                                                                return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={"/scanreports/" + source_id.source_field__scan_report_table__scan_report + "/tables/" + source_id.source_field__scan_report_table__id}> {truncate(source_id.source_field__name)} </Link> </Text>
+                                                            return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}> <Link style={{ color: "#0000FF" }} href={"/scanreports/" + source_id.source_field__scan_report_table__scan_report + "/tables/" + source_id.source_field__scan_report_table__id + "/fields/" + source_id.source_field__id}> {truncate(source_id.source_field__name)} </Link></Text>
                                                         })}
                                                     </div>
 
@@ -56,8 +56,8 @@ function AnalysisTbl({ data }) {
                                                         {descendant.source.map(source_id => {
 
                                                             if (source_id.concept__content_type == 15)
-                                                                return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={"/fields/?search=" + source_id.source_field__scan_report_table__id}> {source_id.source_field__name} </Link></Text>
-                                                            return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={"/values/?search=" + source_id.source_field__id}> {source_id.source_field__name} </Link></Text>
+                                                                return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={"/scanreports/" + source_id.source_field__scan_report_table__scan_report + "/tables/" + source_id.source_field__scan_report_table__id}> {source_id.source_field__name} </Link></Text>
+                                                            return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={"/scanreports/" + source_id.source_field__scan_report_table__scan_report + "/tables/" + source_id.source_field__scan_report_table__id + "/fields/" + source_id.source_field__id}> {source_id.source_field__name} </Link></Text>
                                                         })}
                                                     </div>
                                                 </>

--- a/react-client-app/src/components/EditField.jsx
+++ b/react-client-app/src/components/EditField.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Checkbox, HStack, Text, Button, Flex, Spinner, VStack, Textarea } from "@chakra-ui/react"
 import { useGet, usePatch } from '../api/values'
 const EditField = ({ setTitle }) => {
-    const value = window.pk?window.pk:window.location.href.split("fields/")[1].split("/")[0]
+    const value = window.pk ? window.pk : window.location.href.split("fields/")[1].split("/")[0]
     const [field, setField] = useState(null);
     const [isIgnore, setIsIgnore] = useState(false);
     const [passFromSource, setPassFromSource] = useState(false);
@@ -33,7 +33,7 @@ const EditField = ({ setTitle }) => {
         // use endpoint to change scan report field value
         usePatch(`/scanreportfields/${value}/`, data).then((res) => {
             // redirect
-            window.location.href= `/fields/?search=${field.scan_report_table}`
+            window.location.href = "/scanreports/" + window.location.href.split("scanreports/")[1].split("/")[0] + `/tables/${field.scan_report_table}`
         })
             .catch(err => {
                 console.log(err)

--- a/react-client-app/src/components/EditTable.jsx
+++ b/react-client-app/src/components/EditTable.jsx
@@ -56,7 +56,7 @@ const EditTable = () => {
         }
         usePatch(`/scanreporttables/${value}/`, data).then((res) => {
             // redirect
-            window.location.href = `/tables/?search=${table.scan_report}`
+            window.location.href = `/scanreports/${table.scan_report}`
         })
             .catch(err => {
                 setAlert({

--- a/react-client-app/src/components/FieldsTbl.jsx
+++ b/react-client-app/src/components/FieldsTbl.jsx
@@ -186,7 +186,7 @@ const FieldsTbl = (props) => {
                                             )}
                                         </Formik>
                                     </Td>
-                                    {window.canEdit && <Td><Link style={{ color: "#0000FF", }} href={"/fields/" + item.id + "/update/"}>Edit Field</Link></Td>}
+                                    {window.canEdit && <Td><Link style={{ color: "#0000FF", }} href={window.location.href + "/fields/" + item.id + "/update"}>Edit Field</Link></Td>}
                                 </Tr>
                             )
                         }

--- a/react-client-app/src/components/MappingTbl.jsx
+++ b/react-client-app/src/components/MappingTbl.jsx
@@ -326,7 +326,7 @@ const MappingTbl = () => {
             <MappingModal isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
                 <SummaryTbl values={values}
                     filters={filters} removeFilter={removeFilter} setDestinationFilter={setDestinationFilter} setSourceFilter={setSourceFilter}
-                    destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} />
+                    destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} scanReportId={scan_report_id} />
             </MappingModal>
             <AnalysisModal isOpenAnalyse={isOpenAnalyse} onOpenAnalyse={onOpenAnalyse} onCloseAnalyse={onCloseAnalyse}>
                 <ConceptAnalysis data={data} />
@@ -367,7 +367,7 @@ const MappingTbl = () => {
                 :
                 <RulesTbl values={values}
                     filters={filters} removeFilter={removeFilter} setDestinationFilter={setDestinationFilter} setSourceFilter={setSourceFilter}
-                    destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} applyFilters={applyFilters} />
+                    destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} applyFilters={applyFilters} scanReportId={scan_report_id} />
 
             }
         </div>

--- a/react-client-app/src/components/RulesTbl.jsx
+++ b/react-client-app/src/components/RulesTbl.jsx
@@ -14,7 +14,7 @@ import {
 } from "@chakra-ui/react"
 import { ArrowForwardIcon } from '@chakra-ui/icons'
 import ConceptTag from './ConceptTag'
-function RulesTbl({ values, filters, removeFilter, setDestinationFilter, setSourceFilter, destinationTableFilter, sourceTableFilter, applyFilters }) {
+function RulesTbl({ values, filters, removeFilter, setDestinationFilter, setSourceFilter, destinationTableFilter, sourceTableFilter, applyFilters, scanReportId }) {
     return (
         <div>
             <div style={{ display: "flex", flexWrap: "wrap" }}>
@@ -68,8 +68,8 @@ function RulesTbl({ values, filters, removeFilter, setDestinationFilter, setSour
                                 <Td maxW={[50, 100, 200]} >{item.rule_id} </Td>
                                 <Td maxW={[50, 100, 200]} >{item.destination_table.name} </Td>
                                 <Td maxW={[50, 100, 200]} >{item.destination_field.name}</Td>
-                                <Td maxW={[50, 100, 200]} ><Link style={{ color: "#0000FF", }} href={"/fields/?search=" + item.source_table.id}>{item.source_table.name}</Link></Td>
-                                <Td maxW={[50, 100, 200]} ><Link style={{ color: "#0000FF", }} href={"/values/?search=" + item.source_field.id}>{item.source_field.name}</Link></Td>
+                                <Td maxW={[50, 100, 200]} ><Link style={{ color: "#0000FF", }} href={"/scanreports/" + scanReportId + "/tables/" + item.source_table.id}>{item.source_table.name}</Link></Td>
+                                <Td maxW={[50, 100, 200]} ><Link style={{ color: "#0000FF", }} href={"/scanreports/" + scanReportId + "/tables/" + item.source_table.id + "/fields/" + item.source_field.id}>{item.source_field.name}</Link></Td>
                                 <Td maxW={[50, 100, 200]} >
                                     {item.term_mapping != null &&
                                         <>

--- a/react-client-app/src/components/SummaryTbl.jsx
+++ b/react-client-app/src/components/SummaryTbl.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import RulesTbl from './RulesTbl'
-function SummaryTbl({ values, filters,removeFilter, setDestinationFilter,setSourceFilter,destinationTableFilter,sourceTableFilter }) {
+function SummaryTbl({ values, filters, removeFilter, setDestinationFilter, setSourceFilter, destinationTableFilter, sourceTableFilter, scanReportId }) {
     const applyFilters = (variable) => {
         let newData = variable.map((scanreport) => scanreport);
         newData = newData.filter((rule) => !rule.destination_field.name.includes('_source_concept_id'));
@@ -15,10 +15,10 @@ function SummaryTbl({ values, filters,removeFilter, setDestinationFilter,setSour
     }
     return (
         <div>
-            
+
             <RulesTbl values={values}
-                filters={filters}removeFilter={removeFilter} setDestinationFilter={setDestinationFilter}setSourceFilter={setSourceFilter}
-                destinationTableFilter={destinationTableFilter}sourceTableFilter={sourceTableFilter} applyFilters={applyFilters}/>
+                filters={filters} removeFilter={removeFilter} setDestinationFilter={setDestinationFilter} setSourceFilter={setSourceFilter}
+                destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} applyFilters={applyFilters} scanReportId={scanReportId} />
         </div>
     )
 }

--- a/react-client-app/src/components/TablesTbl.jsx
+++ b/react-client-app/src/components/TablesTbl.jsx
@@ -153,7 +153,7 @@ const TablesTbl = () => {
                                 <Td maxW={"200px"}><Link style={{ color: "#0000FF", }} href={`/scanreports/${scanReportId}/tables/${item.id}`}>{item.name}</Link></Td>
                                 <Td maxW={"200px"}>{item.person_id ? item.person_id.name : null} </Td>
                                 <Td maxW={"200px"}>{item.date_event ? item.date_event.name : null}</Td>
-                                {window.canEdit && <Td maxW={"200px"}><Link style={{ color: "#0000FF", }} href={"/tables/" + item.id + "/update/"}>Edit Table</Link></Td>}
+                                {window.canEdit && <Td maxW={"200px"}><Link style={{ color: "#0000FF", }} href={"/scanreports/" + item.scan_report + "/tables/" + item.id + "/update"}>Edit Table</Link></Td>}
                             </Tr>
 
                         )


### PR DESCRIPTION
# Changes

- Fixed Source Table & Source Field links in Mapping Rules page, Summary View and Analysis View
- Deleted old Edit Table view
- Linked to new Edit Table view and fixed redirect on submit
- Deleted old Edit Field view
- Linked to new Edit Field and fixed redirect on submit

**Cannot remove these List views, new pages rely on them**
` path("scanreports/", views.ScanReportListView.as_view(), name="scan-report-list")`
`path("tables/", views.ScanReportTableListView.as_view(), name="tables") ` 
`path("fields/", views.ScanReportFieldListView.as_view(), name="fields")`
`path("values/", views.ScanReportValueListView.as_view(), name="values")`

_Removed all links pointing to tables/?search={id} or fields/?search={id}_

   

# Migrations

# Screenshots

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
