### PR TITLE
Bugfix/only editors or admins can create

### DIFF
--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -33,6 +33,12 @@ from .services_rules import (
     get_mapping_rules_list,
 )
 
+from .permissions import (
+    has_editorship,
+    has_viewership,
+    is_admin,
+)
+
 
 class ConceptSerializer(serializers.ModelSerializer):
     class Meta:
@@ -97,11 +103,7 @@ class ScanReportViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     def validate_author(self, author):
         if request := self.context.get("request"):
-            user = request.user
-            if not (
-                self.instance.author.id == user.id
-                or self.instance.parent_dataset.admins.filter(id=user.id).exists()
-            ):
+            if not is_admin(self.instance, request):
                 raise serializers.ValidationError(
                     """You must be the author of the scan report or an admin of the parent dataset 
                     to change this field."""
@@ -110,11 +112,7 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_viewers(self, viewers):
         if request := self.context.get("request"):
-            user = request.user
-            if not (
-                self.instance.author.id == user.id
-                or self.instance.parent_dataset.admins.filter(id=user.id).exists()
-            ):
+            if not is_admin(self.instance, request):
                 raise serializers.ValidationError(
                     """You must be the author of the scan report or an admin of the parent dataset 
                     to change this field."""
@@ -123,11 +121,7 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_editors(self, editors):
         if request := self.context.get("request"):
-            user = request.user
-            if not (
-                self.instance.author.id == user.id
-                or self.instance.parent_dataset.admins.filter(id=user.id).exists()
-            ):
+            if not is_admin(self.instance, request):
                 raise serializers.ValidationError(
                     """You must be the author of the scan report or an admin of the parent dataset 
                     to change this field."""

--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -142,8 +142,7 @@ class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     def validate_viewers(self, viewers):
         if request := self.context.get("request"):
-            user = request.user
-            if not self.instance.admins.filter(id=user.id).exists():
+            if not is_admin(self.instance, request):
                 raise serializers.ValidationError(
                     "You must be an admin to change this field."
                 )
@@ -151,8 +150,7 @@ class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_editors(self, editors):
         if request := self.context.get("request"):
-            user = request.user
-            if not self.instance.admins.filter(id=user.id).exists():
+            if not is_admin(self.instance, request):
                 raise serializers.ValidationError(
                     "You must be an admin to change this field."
                 )
@@ -160,8 +158,7 @@ class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_admins(self, admins):
         if request := self.context.get("request"):
-            user = request.user
-            if not self.instance.admins.filter(id=user.id).exists():
+            if not is_admin(self.instance, request):
                 raise serializers.ValidationError(
                     "You must be an admin to change this field."
                 )

--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -258,7 +258,7 @@ class ScanReportFieldSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
         fields = "__all__"
 
 
-class ScanReportValueSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class ScanReportValueViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     value = serializers.CharField(
         max_length=128, allow_blank=True, trim_whitespace=False
     )
@@ -281,6 +281,16 @@ class ScanReportValueSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
                 "Missing request context. Unable to validate scan report value."
             )
         return super().validate(data)
+
+    class Meta:
+        model = ScanReportValue
+        fields = "__all__"
+
+
+class ScanReportValueEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    value = serializers.CharField(
+        max_length=128, allow_blank=True, trim_whitespace=False
+    )
 
     class Meta:
         model = ScanReportValue

--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -226,7 +226,7 @@ class ScanReportTableSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
         fields = "__all__"
 
 
-class ScanReportFieldSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class ScanReportFieldListSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     name = serializers.CharField(
         max_length=512, allow_blank=True, trim_whitespace=False
     )
@@ -252,6 +252,19 @@ class ScanReportFieldSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
                 "Missing request context. Unable to validate scan report field."
             )
         return super().validate(data)
+
+    class Meta:
+        model = ScanReportField
+        fields = "__all__"
+
+
+class ScanReportFieldEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    name = serializers.CharField(
+        max_length=512, allow_blank=True, trim_whitespace=False
+    )
+    description_column = serializers.CharField(
+        max_length=512, allow_blank=True, trim_whitespace=False
+    )
 
     class Meta:
         model = ScanReportField

--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -201,7 +201,7 @@ class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         fields = "__all__"
 
 
-class ScanReportTableSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class ScanReportTableListSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     def validate(self, data):
         if request := self.context.get("request"):
             if sr := data.get("scan_report"):
@@ -221,6 +221,12 @@ class ScanReportTableSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
             )
         return super().validate(data)
 
+    class Meta:
+        model = ScanReportTable
+        fields = "__all__"
+
+
+class ScanReportTableEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = ScanReportTable
         fields = "__all__"

--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.status import HTTP_403_FORBIDDEN
+from rest_framework.exceptions import PermissionDenied, NotFound
 from drf_dynamic_fields import DynamicFieldsMixin
 from django.contrib.auth.models import User
 from data.models import (
@@ -107,8 +106,9 @@ class ScanReportViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
                 ):
                     raise PermissionDenied(
                         "You must be an admin of the parent dataset to add a new scan report to it.",
-                        code=HTTP_403_FORBIDDEN,
                     )
+            else:
+                raise NotFound("Could not find parent dataset.")
         else:
             raise serializers.ValidationError(
                 "Missing request context. Unable to validate scan report"

--- a/api/mapping/serializers.py
+++ b/api/mapping/serializers.py
@@ -34,9 +34,8 @@ from .services_rules import (
 )
 
 from .permissions import (
-    has_editorship,
-    has_viewership,
     is_admin,
+    is_az_function_user,
 )
 
 
@@ -103,7 +102,9 @@ class ScanReportViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     def validate_author(self, author):
         if request := self.context.get("request"):
-            if not is_admin(self.instance, request):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
                 raise serializers.ValidationError(
                     """You must be the author of the scan report or an admin of the parent dataset 
                     to change this field."""
@@ -112,7 +113,9 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_viewers(self, viewers):
         if request := self.context.get("request"):
-            if not is_admin(self.instance, request):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
                 raise serializers.ValidationError(
                     """You must be the author of the scan report or an admin of the parent dataset 
                     to change this field."""
@@ -121,7 +124,9 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_editors(self, editors):
         if request := self.context.get("request"):
-            if not is_admin(self.instance, request):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
                 raise serializers.ValidationError(
                     """You must be the author of the scan report or an admin of the parent dataset 
                     to change this field."""
@@ -142,7 +147,9 @@ class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     def validate_viewers(self, viewers):
         if request := self.context.get("request"):
-            if not is_admin(self.instance, request):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
                 raise serializers.ValidationError(
                     "You must be an admin to change this field."
                 )
@@ -150,7 +157,9 @@ class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_editors(self, editors):
         if request := self.context.get("request"):
-            if not is_admin(self.instance, request):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
                 raise serializers.ValidationError(
                     "You must be an admin to change this field."
                 )
@@ -158,7 +167,9 @@ class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     def validate_admins(self, admins):
         if request := self.context.get("request"):
-            if not is_admin(self.instance, request):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
                 raise serializers.ValidationError(
                     "You must be an admin to change this field."
                 )

--- a/api/mapping/test_serializers.py
+++ b/api/mapping/test_serializers.py
@@ -25,6 +25,13 @@ class TestScanReportEditSerializer(TestCase):
         )
         self.editor_user = User.objects.create(username="sauron", password="oijfowfjef")
         self.project = Project.objects.create(name="The Fellowship of The Ring")
+        self.project.members.add(
+            self.admin_user,
+            self.author_user,
+            self.non_viewer_user,
+            self.viewer_user,
+            self.editor_user,
+        )
         self.data_partner = DataPartner.objects.create(name="Silvan Elves")
         self.public_dataset = Dataset.objects.create(
             name="Places in Middle Earth",

--- a/api/mapping/test_serializers.py
+++ b/api/mapping/test_serializers.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIRequestFactory
 from rest_framework.authtoken.models import Token
 from rest_framework.serializers import ValidationError
 from .models import Project, Dataset, ScanReport, VisibilityChoices, DataPartner
-from .serializers import ScanReportEditSerializer
+from .serializers import ScanReportEditSerializer, DatasetEditSerializer
 
 
 class TestScanReportEditSerializer(TestCase):
@@ -205,3 +205,163 @@ class TestScanReportEditSerializer(TestCase):
         # check admin can alter author
         request.user = self.admin_user
         self.assertEqual(serializer.validate_author(new_author), new_author)
+
+
+class TestDatasetEditSerializer(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin_user = User.objects.create(
+            username="gandalf", password="onfwojeijfe"
+        )
+        self.non_viewer_user = User.objects.create(
+            username="saruman", password="pjwjfefjefew"
+        )
+        self.viewer_user = User.objects.create(
+            username="thewatcher", password="oidoijewfoj"
+        )
+        self.editor_user = User.objects.create(username="sauron", password="oijfowfjef")
+        self.project = Project.objects.create(name="The Fellowship of The Ring")
+        self.project.members.add(
+            self.admin_user,
+            self.non_viewer_user,
+            self.viewer_user,
+            self.editor_user,
+        )
+        self.data_partner = DataPartner.objects.create(name="Silvan Elves")
+        self.dataset = Dataset.objects.create(
+            name="Forbidden Places in Middle Earth",
+            visibility=VisibilityChoices.RESTRICTED,
+            data_partner=self.data_partner,
+        )
+        self.dataset.admins.add(self.admin_user)
+        self.project.datasets.add(self.dataset)
+
+    def test_validate_editors(self):
+        User = get_user_model()
+        new_editor = User.objects.create(username="samwise", password="ejojwejfefe")
+        request = APIRequestFactory().patch(
+            "/the/path/to/isengard", data={"editors": [new_editor]}
+        )
+        serializer = DatasetEditSerializer(
+            self.dataset,
+            data={"editors": [new_editor]},
+            context={"request": request},
+        )
+        # check non admin can't alter editors
+        request.user = self.non_viewer_user
+        self.assertRaises(
+            ValidationError, serializer.validate_editors, editors=[new_editor]
+        )
+
+        # check viewer can't alter editors on restricted SRs
+        request.user = self.viewer_user
+        self.dataset.viewers.add(self.viewer_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_editors, editors=[new_editor]
+        )
+        self.dataset.viewers.remove(self.viewer_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_editors, editors=[new_editor]
+        )
+
+        # check editor can't alter editors on restricted SRs
+        request.user = self.editor_user
+        self.dataset.viewers.add(self.editor_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_editors, editors=[new_editor]
+        )
+        self.dataset.viewers.remove(self.editor_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_editors, editors=[new_editor]
+        )
+
+        # check admin can alter editors
+        request.user = self.admin_user
+        self.assertListEqual(serializer.validate_editors([new_editor]), [new_editor])
+
+    def test_validate_viewers(self):
+        User = get_user_model()
+        new_viewer = User.objects.create(username="samwise", password="ejojwejfefe")
+        request = APIRequestFactory().patch(
+            "/the/path/to/isengard", data={"viewers": [new_viewer]}
+        )
+        serializer = DatasetEditSerializer(
+            self.dataset,
+            data={"viewers": [new_viewer]},
+            context={"request": request},
+        )
+        # check non admin can't alter viewers
+        request.user = self.non_viewer_user
+        self.assertRaises(
+            ValidationError, serializer.validate_viewers, viewers=[new_viewer]
+        )
+
+        # check viewer can't alter viewers on restricted SRs
+        request.user = self.viewer_user
+        self.dataset.viewers.add(self.viewer_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_viewers, viewers=[new_viewer]
+        )
+        self.dataset.viewers.remove(self.viewer_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_viewers, viewers=[new_viewer]
+        )
+
+        # check editor can't alter viewers on restricted SRs
+        request.user = self.editor_user
+        self.dataset.viewers.add(self.editor_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_viewers, viewers=[new_viewer]
+        )
+        self.dataset.viewers.remove(self.editor_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_viewers, viewers=[new_viewer]
+        )
+
+        # check admin can alter viewers
+        request.user = self.admin_user
+        self.assertListEqual(serializer.validate_viewers([new_viewer]), [new_viewer])
+
+    def test_validate_admin(self):
+        User = get_user_model()
+        new_admin = User.objects.create(username="samwise", password="ejojwejfefe")
+        request = APIRequestFactory().patch(
+            "/the/path/to/isengard", data={"admin": new_admin}
+        )
+        serializer = DatasetEditSerializer(
+            self.dataset,
+            data={"admin": new_admin},
+            context={"request": request},
+        )
+
+        # check non admin can't alter author
+        request.user = self.non_viewer_user
+        self.assertRaises(
+            ValidationError, serializer.validate_admins, admins=[new_admin]
+        )
+
+        # check viewer can't alter author on restricted SRs
+        request.user = self.viewer_user
+        self.dataset.viewers.add(self.viewer_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_admins, admins=[new_admin]
+        )
+        self.dataset.viewers.remove(self.viewer_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_admins, admins=[new_admin]
+        )
+
+        # check editor can't alter admins on restricted SRs
+        request.user = self.editor_user
+        self.dataset.viewers.add(self.editor_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_admins, admins=[new_admin]
+        )
+        self.dataset.viewers.remove(self.editor_user)
+        self.assertRaises(
+            ValidationError, serializer.validate_admins, admins=[new_admin]
+        )
+
+        # check admin can alter admins
+        request.user = self.admin_user
+        self.assertEqual(serializer.validate_admins(new_admin), new_admin)

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -22,7 +22,8 @@ from .serializers import (
     ScanReportEditSerializer,
     ScanReportViewSerializer,
     ScanReportTableSerializer,
-    ScanReportFieldSerializer,
+    ScanReportFieldEditSerializer,
+    ScanReportFieldListSerializer,
     ScanReportValueEditSerializer,
     ScanReportValueViewSerializer,
     ScanReportConceptSerializer,
@@ -545,7 +546,6 @@ class ScanReportTableViewSet(viewsets.ModelViewSet):
 
 class ScanReportFieldViewSet(viewsets.ModelViewSet):
     queryset = ScanReportField.objects.all()
-    serializer_class = ScanReportFieldSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         "scan_report_table": ["in", "exact"],
@@ -564,6 +564,15 @@ class ScanReportFieldViewSet(viewsets.ModelViewSet):
         else:
             self.permission_classes = [CanView | CanEdit | CanAdmin]
         return [permission() for permission in self.permission_classes]
+
+    def get_serializer_class(self):
+        if self.request.method in ["GET", "POST"]:
+            # use the view serialiser if on GET requests
+            return ScanReportFieldListSerializer
+        if self.request.method in ["PUT", "PATCH", "DELETE"]:
+            # use the edit serialiser when the user tries to alter the scan report
+            return ScanReportFieldEditSerializer
+        return super().get_serializer_class()
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(
@@ -726,7 +735,6 @@ class MappingRuleFilterViewSet(viewsets.ModelViewSet):
 
 class ScanReportValueViewSet(viewsets.ModelViewSet):
     queryset = ScanReportValue.objects.all()
-    serializer_class = ScanReportValueViewSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         "scan_report_field": ["in", "exact"],

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -21,7 +21,8 @@ from .serializers import (
     GetRulesAnalysis,
     ScanReportEditSerializer,
     ScanReportViewSerializer,
-    ScanReportTableSerializer,
+    ScanReportTableEditSerializer,
+    ScanReportTableListSerializer,
     ScanReportFieldEditSerializer,
     ScanReportFieldListSerializer,
     ScanReportValueEditSerializer,
@@ -501,7 +502,6 @@ class DatasetDeleteView(generics.DestroyAPIView):
 
 class ScanReportTableViewSet(viewsets.ModelViewSet):
     queryset = ScanReportTable.objects.all()
-    serializer_class = ScanReportTableSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         "scan_report": ["in", "exact"],
@@ -520,6 +520,15 @@ class ScanReportTableViewSet(viewsets.ModelViewSet):
         else:
             self.permission_classes = [CanView | CanEdit | CanAdmin]
         return [permission() for permission in self.permission_classes]
+
+    def get_serializer_class(self):
+        if self.request.method in ["GET", "POST"]:
+            # use the view serialiser if on GET requests
+            return ScanReportTableListSerializer
+        if self.request.method in ["PUT", "PATCH", "DELETE"]:
+            # use the edit serialiser when the user tries to alter the scan report
+            return ScanReportTableEditSerializer
+        return super().get_serializer_class()
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -23,7 +23,8 @@ from .serializers import (
     ScanReportViewSerializer,
     ScanReportTableSerializer,
     ScanReportFieldSerializer,
-    ScanReportValueSerializer,
+    ScanReportValueEditSerializer,
+    ScanReportValueViewSerializer,
     ScanReportConceptSerializer,
     ClassificationSystemSerializer,
     DataDictionarySerializer,
@@ -725,7 +726,7 @@ class MappingRuleFilterViewSet(viewsets.ModelViewSet):
 
 class ScanReportValueViewSet(viewsets.ModelViewSet):
     queryset = ScanReportValue.objects.all()
-    serializer_class = ScanReportValueSerializer
+    serializer_class = ScanReportValueViewSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         "scan_report_field": ["in", "exact"],
@@ -744,6 +745,15 @@ class ScanReportValueViewSet(viewsets.ModelViewSet):
         else:
             self.permission_classes = [CanView | CanEdit | CanAdmin]
         return [permission() for permission in self.permission_classes]
+
+    def get_serializer_class(self):
+        if self.request.method in ["GET", "POST"]:
+            # use the view serialiser if on GET requests
+            return ScanReportValueViewSerializer
+        if self.request.method in ["PUT", "PATCH", "DELETE"]:
+            # use the edit serialiser when the user tries to alter the scan report
+            return ScanReportValueEditSerializer
+        return super().get_serializer_class()
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(
@@ -769,7 +779,7 @@ class ScanReportValueViewSet(viewsets.ModelViewSet):
 
 
 class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
-    serializer_class = ScanReportValueSerializer
+    serializer_class = ScanReportValueViewSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["scan_report_field__scan_report_table__scan_report"]
 
@@ -783,7 +793,7 @@ class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
 
 
 class ScanReportValuesFilterViewSetScanReportTable(viewsets.ModelViewSet):
-    serializer_class = ScanReportValueSerializer
+    serializer_class = ScanReportValueViewSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["scan_report_field__scan_report_table"]
 
@@ -895,7 +905,7 @@ class CountStatsScanReportTableField(APIView):
 # It also removes all conceptIDs which == -1, leaving only those SRVs with a
 # concept_id which has been looked up with omop_helpers
 class ScanReportValuePKViewSet(viewsets.ModelViewSet):
-    serializer_class = ScanReportValueSerializer
+    serializer_class = ScanReportValueViewSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["scan_report_field__scan_report_table__scan_report"]
 


### PR DESCRIPTION
# Changes

- Added permission checks to:
  - `ScanReportViewSerializer`
  - `ScanReportTableSerializer`
  - `ScanReportFieldSerializer`
  - `ScanReportValueSerializer`
- Prevents unauthorised users from creating resources they shouldn't.
- Updated permission checks in:
  - `DatasetEditSerializer`
  - `ScanReportTableSerializer`
- These now check the azure user's permissions. 
- Created separate list/edit serialisers for SR tables/fields/values.

# Migrations
# Screenshots
# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [X] Run unit tests.
