### PR TITLE
made mapping buttons responsive

### DIFF
--- a/react-client-app/src/components/MappingTbl.jsx
+++ b/react-client-app/src/components/MappingTbl.jsx
@@ -1,18 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react'
 import {
-    Table,
-    Thead,
-    Tbody,
-    Tr,
-    Th,
-    Td,
-    TableCaption,
-    HStack,
-    VStack,
     Flex,
     Spinner,
     Link,
-    Select,
+    Wrap,
     Button,
     useDisclosure,
 } from "@chakra-ui/react"
@@ -345,7 +336,7 @@ const MappingTbl = (props) => {
                 <Link href={`/scanreports/${scan_report_id}/mapping_rules/`}>Mapping Rules</Link>
             </CCBreadcrumbBar>
             <PageHeading text={"Mapping Rules"} />
-            <HStack my="10px">
+            <Wrap my="10px">
                 <Button variant="green" onClick={() => { refreshRules() }}>Refresh Rules</Button>
                 <Button variant="blue" isLoading={isDownloading} loadingText="Downloading" spinnerPlacement="start" onClick={downloadRules}>Download Mapping JSON</Button>
                 <Button variant="yellow" onClick={() => { setMapDiagram(mapDiagram => ({ ...mapDiagram, showing: !mapDiagram.showing })) }}>{mapDiagram.showing ? "Hide " : "View "}Map Diagram</Button>
@@ -353,7 +344,7 @@ const MappingTbl = (props) => {
                 <Button variant="blue" isLoading={isDownloadingCSV} loadingText="Downloading" spinnerPlacement="start" onClick={downloadCSV}>Download Mapping CSV</Button>
                 <Button variant="blue" onClick={onOpen}>Show Summary view</Button>
                 <Button variant="blue" onClick={onOpenAnalyse}>Analyse Rules</Button>
-            </HStack>
+            </Wrap>
 
             <div>
                 {mapDiagram.showing &&


### PR DESCRIPTION
# Changes
- Made buttons in mapping rules page responsive

# Migrations


# Screenshots
<img width="872" alt="image" src="https://user-images.githubusercontent.com/38753056/166432653-f0dd3bb3-a02e-4fd5-b8ff-18bd36c270ed.png">

<img width="565" alt="image" src="https://user-images.githubusercontent.com/38753056/166432681-0d109707-b764-4ffa-a75c-c17db377120a.png">

<img width="248" alt="image" src="https://user-images.githubusercontent.com/38753056/166432708-ffb5262c-1216-4356-b9bf-4acbc87b7c1b.png">


# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
