### PR TITLE
Bugfix/add viewers editors at sr upload

### DIFF
--- a/api/mapping/forms.py
+++ b/api/mapping/forms.py
@@ -37,10 +37,22 @@ class ScanReportForm(forms.Form):
         queryset=Dataset.objects.order_by("name"),
         widget=forms.Select(attrs={"class": "form-control"}),
     )
+    viewers = forms.ModelMultipleChoiceField(
+        label="Viewers",
+        queryset=User.objects.order_by("username"),
+        widget=forms.SelectMultiple(attrs={"class": "form-control"}),
+        required=False,
+    )
+    editors = forms.ModelMultipleChoiceField(
+        label="Editors",
+        queryset=User.objects.order_by("username"),
+        widget=forms.SelectMultiple(attrs={"class": "form-control"}),
+        required=False,
+    )
 
     class Meta:
         model = ScanReport
-        fields = ("dataset", "scan_report_file", "parent_dataset")
+        fields = ("dataset", "scan_report_file", "parent_dataset", "editors", "viewers")
 
     def clean_data_dictionary_file(self):
 

--- a/api/mapping/forms.py
+++ b/api/mapping/forms.py
@@ -5,7 +5,12 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.forms.models import ModelChoiceField
 
-from mapping.models import DataPartner, Dataset, ScanReportField, ScanReport
+from mapping.models import (
+    Dataset,
+    ScanReportField,
+    ScanReport,
+    VisibilityChoices,
+)
 import openpyxl
 import csv
 from io import BytesIO, StringIO
@@ -49,10 +54,22 @@ class ScanReportForm(forms.Form):
         widget=forms.SelectMultiple(attrs={"class": "form-control"}),
         required=False,
     )
+    visibility = forms.ChoiceField(
+        label="Visibility",
+        choices=VisibilityChoices.choices,
+        widget=forms.Select(attrs={"class": "form-control"}),
+    )
 
     class Meta:
         model = ScanReport
-        fields = ("dataset", "scan_report_file", "parent_dataset", "editors", "viewers")
+        fields = (
+            "dataset",
+            "scan_report_file",
+            "parent_dataset",
+            "editors",
+            "viewers",
+            "visibility",
+        )
 
     def clean_data_dictionary_file(self):
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1152,6 +1152,13 @@ class ScanReportFormView(FormView):
         ):
             return self.form_invalid(form)
 
+        # Form is invalid if visibility is restricted and no viewers are set
+        if (
+            form.cleaned_data["visibility"] == VisibilityChoices.RESTRICTED
+            and not form.cleaned_data["viewers"]
+        ):
+            return self.form_invalid(form)
+
         # Create random alphanumeric to link scan report to data dictionary
         # Create datetime stamp for scan report and data dictionary upload time
         rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
@@ -1162,6 +1169,7 @@ class ScanReportFormView(FormView):
             dataset=form.cleaned_data["dataset"],
             parent_dataset=parent_dataset,
             name=modify_filename(form.cleaned_data.get("scan_report_file"), dt, rand),
+            visibility=form.cleaned_data["visibility"],
         )
 
         scan_report.author = self.request.user

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1152,13 +1152,6 @@ class ScanReportFormView(FormView):
         ):
             return self.form_invalid(form)
 
-        # Form is invalid if visibility is restricted and no viewers are set
-        if (
-            form.cleaned_data["visibility"] == VisibilityChoices.RESTRICTED
-            and not form.cleaned_data["viewers"]
-        ):
-            return self.form_invalid(form)
-
         # Create random alphanumeric to link scan report to data dictionary
         # Create datetime stamp for scan report and data dictionary upload time
         rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1167,6 +1167,14 @@ class ScanReportFormView(FormView):
         scan_report.author = self.request.user
         scan_report.save()
 
+        # Add viewers to the scan report if specified
+        if sr_viewers := form.cleaned_data.get("viewers"):
+            scan_report.viewers.add(*sr_viewers)
+
+        # Add editors to the scan report if specified
+        if sr_editors := form.cleaned_data.get("editors"):
+            scan_report.editors.add(*sr_editors)
+
         # Grab Azure storage credentials
         blob_service_client = BlobServiceClient.from_connection_string(
             os.getenv("STORAGE_CONN_STRING")

--- a/changelog.md
+++ b/changelog.md
@@ -91,6 +91,10 @@ Please append a line to the changelog for each change made.
 * User will see a generic error message when they navigate to a dataset or scan report detail/admin page which they do not have permission to view (or it does not exist).
 * New breadcrumb mechanic.
 * User will now be shown an alert dialogue when they try to archive a dataset that they don't have editor permissions to and the dataset will not be archived
+* `visibility` set on SR when uploaded.
+* `viewers` and `editors` set on SR when uploaded.
+* `editors` set on creation of new dataset on SR upload page.
+* `editors` and `admins` field for dataset shown for PUBLIC dataset as well as RESTRICTED.
 
 ## v1.4.0 was released 02/02/22
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ Please append a line to the changelog for each change made.
 ### New Features
 
 ### Improvements
+* `visibility` set on SR when uploaded.
+* `viewers` and `editors` set on SR when uploaded.
+* `editors` set on creation of new dataset on SR upload page.
+* `editors` and `admins` field for dataset shown for PUBLIC dataset as well as RESTRICTED.
 
 ### Bugfixes
 
@@ -98,10 +102,6 @@ Please append a line to the changelog for each change made.
 * User will see a generic error message when they navigate to a dataset or scan report detail/admin page which they do not have permission to view (or it does not exist).
 * New breadcrumb mechanic.
 * User will now be shown an alert dialogue when they try to archive a dataset that they don't have editor permissions to and the dataset will not be archived
-* `visibility` set on SR when uploaded.
-* `viewers` and `editors` set on SR when uploaded.
-* `editors` set on creation of new dataset on SR upload page.
-* `editors` and `admins` field for dataset shown for PUBLIC dataset as well as RESTRICTED.
 
 ## v1.4.0 was released 02/02/22
 

--- a/react-client-app/src/components/UploadScanReport.jsx
+++ b/react-client-app/src/components/UploadScanReport.jsx
@@ -227,9 +227,6 @@ const UploadScanReport = ({ setTitle }) => {
             if (dataDictionary && dataDictionary.name.split('.').pop() != "csv") {
                 throw { statusText: "You have attempted to upload a data dictionary which is not in csv format. Please upload a .csv file" }
             }
-            if (!scanReportIsPublic && scanreportViewers.length == 0) {
-                throw { statusText: "RESTRICTED scan reports must have at least one Viewer." }
-            }
             // The tests on the backend will also trigger an error
 
             let formData = new FormData()

--- a/react-client-app/src/components/UploadScanReport.jsx
+++ b/react-client-app/src/components/UploadScanReport.jsx
@@ -228,12 +228,13 @@ const UploadScanReport = ({ setTitle }) => {
             // The tests on the backend will also trigger an error
 
             let formData = new FormData()
-            await formData.append('parent_dataset', selectedDataset.id)
-            await formData.append('dataset', scanReportName.current.value)
-            await formData.append('scan_report_file', whiteRabbitScanReport)
-            await formData.append('data_dictionary_file', dataDictionary)
-            await formData.append('viewers', scanreportViewers.map(item => item.id))
-            await formData.append('editors', scanreportEditors.map(item => item.id))
+            formData.append('parent_dataset', selectedDataset.id)
+            formData.append('dataset', scanReportName.current.value)
+            formData.append('scan_report_file', whiteRabbitScanReport)
+            formData.append('data_dictionary_file', dataDictionary)
+            scanreportViewers.forEach(viewer => formData.append("viewers", viewer.id))
+            scanreportEditors.forEach(editor => formData.append("editors", editor.id))
+            console.log([...formData.entries()])
             setUploadLoading(true)
 
             const response = await postForm(window.location.href, formData)

--- a/react-client-app/src/components/UploadScanReport.jsx
+++ b/react-client-app/src/components/UploadScanReport.jsx
@@ -509,7 +509,7 @@ const UploadScanReport = ({ setTitle }) => {
                 checkedMessage={"PUBLIC"}
                 notCheckedMessage={"RESTRICTED"}
             />
-            {scanReportIsPublic &&
+            {!scanReportIsPublic &&
                 <CCMultiSelectInput
                     id={"scanreport-viewers"}
                     label={"Viewers"}

--- a/react-client-app/src/components/UploadScanReport.jsx
+++ b/react-client-app/src/components/UploadScanReport.jsx
@@ -9,6 +9,7 @@ import ToastAlert from './ToastAlert'
 import ConceptTag from './ConceptTag'
 import CCBreadcrumbBar from './CCBreadcrumbBar'
 import CCMultiSelectInput from './CCMultiSelectInput'
+import CCSwitchInput from './CCSwitchInput'
 
 const UploadScanReport = ({ setTitle }) => {
 
@@ -42,6 +43,7 @@ const UploadScanReport = ({ setTitle }) => {
 
     const scanReportName = useRef();
     const createDatasetRef = useRef();
+    const [scanReportIsPublic, setScanReportIsPublic] = useState(true);
     const [whiteRabbitScanReport, setWhiteRabbitScanReport] = useState(null);
     const [dataDictionary, setDataDictionary] = useState(null);
     const [loadingMessage, setLoadingMessage] = useState("Loading page")
@@ -232,6 +234,7 @@ const UploadScanReport = ({ setTitle }) => {
             formData.append('dataset', scanReportName.current.value)
             formData.append('scan_report_file', whiteRabbitScanReport)
             formData.append('data_dictionary_file', dataDictionary)
+            formData.append('visibility', scanReportIsPublic ? "PUBLIC" : "RESTRICTED")
             scanreportViewers.forEach(viewer => formData.append("viewers", viewer.id))
             scanreportEditors.forEach(editor => formData.append("editors", editor.id))
             console.log([...formData.entries()])
@@ -498,17 +501,26 @@ const UploadScanReport = ({ setTitle }) => {
                     </Box>
                 }
             </Box>
-
-            <CCMultiSelectInput
-                id={"scanreport-viewers"}
-                label={"Viewers"}
-                info={"If the Scan Report is PUBLIC, then all users with access to the Dataset have viewer access to the Scan Report. Additionally, Dataset admins and editors have viewer access to the Scan Report in all cases."}
-                isLoading={loadingDatasetProjects}
-                selectOptions={activeUsersList ? activeUsersList.filter(item => selectedDatasetProjectMembers.includes(item.id)).map(item => item.username) : []}
-                currentSelections={scanreportViewers.map(item => item.username)}
-                handleInput={addScanreportViewer}
-                handleDelete={removeScanreportViewer}
+            <CCSwitchInput
+                id={"scanreport-visibility"}
+                label={"Visibility"}
+                isChecked={scanReportIsPublic}
+                handleInput={setScanReportIsPublic}
+                checkedMessage={"PUBLIC"}
+                notCheckedMessage={"RESTRICTED"}
             />
+            {scanReportIsPublic &&
+                <CCMultiSelectInput
+                    id={"scanreport-viewers"}
+                    label={"Viewers"}
+                    info={"If the Scan Report is PUBLIC, then all users with access to the Dataset have viewer access to the Scan Report. Additionally, Dataset admins and editors have viewer access to the Scan Report in all cases."}
+                    isLoading={loadingDatasetProjects}
+                    selectOptions={activeUsersList ? activeUsersList.filter(item => selectedDatasetProjectMembers.includes(item.id)).map(item => item.username) : []}
+                    currentSelections={scanreportViewers.map(item => item.username)}
+                    handleInput={addScanreportViewer}
+                    handleDelete={removeScanreportViewer}
+                />
+            }
 
             <CCMultiSelectInput
                 id={"scanreport-editors"}


### PR DESCRIPTION
# Changes

- `visibility` set on SR when uploaded.
- `viewers` and `editors` set on SR when uploaded.
- `editors` set on creation of new dataset on SR upload page.
- `editors` and `admins` field for dataset shown for PUBLIC dataset as well as RESTRICTED.

# Migrations
# Screenshots
# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
