### PR TITLE
Datasets admin projects endpoints

### DIFF
--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -124,7 +124,11 @@ routers.register(
 routers.register(r"analyse", views.AnalyseRules, basename="getanalysis")
 
 urlpatterns = [
-    path(r"api/countprojects/<int:dataset>", views.CountProjects.as_view(), name="countprojects"),
+    path(
+        r"api/countprojects/<int:dataset>",
+        views.CountProjects.as_view(),
+        name="countprojects",
+    ),
     path(r"api/countstats/", views.CountStats.as_view(), name="countstats"),
     path(
         r"api/countstatsscanreport/",

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -124,6 +124,7 @@ routers.register(
 routers.register(r"analyse", views.AnalyseRules, basename="getanalysis")
 
 urlpatterns = [
+    path(r"api/countprojects/<int:dataset>", views.CountProjects.as_view(), name="countprojects"),
     path(r"api/countstats/", views.CountStats.as_view(), name="countstats"),
     path(
         r"api/countstatsscanreport/",

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -212,6 +212,15 @@ class DrugStrengthViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_fields = ["drug_concept_id", "ingredient_concept_id"]
 
 
+class CountProjects(APIView):
+    renderer_classes = (JSONRenderer,)
+    def get(self, request, dataset):   
+        project_count =  Project.objects.filter(datasets__exact=dataset).distinct().count() 
+        content = {
+            "project_count": project_count,
+        }
+        return Response(content)
+        
 class ProjectListView(ListAPIView):
     """
     API view to show all projects' names.

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -214,13 +214,17 @@ class DrugStrengthViewSet(viewsets.ReadOnlyModelViewSet):
 
 class CountProjects(APIView):
     renderer_classes = (JSONRenderer,)
-    def get(self, request, dataset):   
-        project_count =  Project.objects.filter(datasets__exact=dataset).distinct().count() 
+
+    def get(self, request, dataset):
+        project_count = (
+            Project.objects.filter(datasets__exact=dataset).distinct().count()
+        )
         content = {
             "project_count": project_count,
         }
         return Response(content)
-        
+
+
 class ProjectListView(ListAPIView):
     """
     API view to show all projects' names.

--- a/react-client-app/src/components/DatasetAdminForm.jsx
+++ b/react-client-app/src/components/DatasetAdminForm.jsx
@@ -32,6 +32,8 @@ const DatasetAdminForm = ({ setTitle }) => {
     const [projectsList, setProjectsList] = useState(undefined)
     const [usersList, setUsersList] = useState(undefined)
     const [error, setError] = useState(undefined)
+    const [projectDifference, setProjectDifference] = useState(0)
+
 
     function getUsersFromIds(userIds, userObjects) {
         /**
@@ -62,10 +64,11 @@ const DatasetAdminForm = ({ setTitle }) => {
                     useGet("/datapartners/"),
                     useGet("/usersfilter/?is_active=true"),
                     useGet(`/projects/?dataset=${datasetId}`),
-                    useGet(`/projects`)
+                    useGet(`/projects`),
+                    useGet(`/countprojects/${datasetId}`),
                 ]
                 // Get dataset, data partners and users
-                const [dataPartnerQuery, usersQuery, projectsQuery, allProjectsQuery] = await Promise.all(queries)
+                const [dataPartnerQuery, usersQuery, projectsQuery, allProjectsQuery, projectCount] = await Promise.all(queries)
                 const validUsers = [...(new Set(projectsQuery.map(project => project.members).flat()))]
                 // Set up state from the results of the queries
                 setDataset(datasetQuery)
@@ -73,6 +76,7 @@ const DatasetAdminForm = ({ setTitle }) => {
                 setDataPartners([...dataPartnerQuery])
                 setProjectsList(allProjectsQuery)
                 setProjects(projectsQuery)
+                setProjectDifference(projectCount.project_count - projectsQuery.length)
                 setSelectedDataPartner(
                     dataPartnerQuery.find(element => element.id === datasetQuery.data_partner)
                 )
@@ -266,6 +270,12 @@ const DatasetAdminForm = ({ setTitle }) => {
                 description: error.statusText ? error.statusText : ""
             })
             onOpen()
+        }
+    }
+
+    const warnUpload = () => {
+        if (confirm(`This Dataset is in ${projectDifference} further Projects that you cannot see. Do you want to continue with this edit?`) == true) {
+            upload()
         }
     }
 
@@ -487,7 +497,7 @@ const DatasetAdminForm = ({ setTitle }) => {
                 </Box>
             </FormControl>
             {isAdmin &&
-                <Button isLoading={uploadLoading} loadingText='Uploading' mt="10px" onClick={upload}>Submit</Button>
+                <Button isLoading={uploadLoading} loadingText='Uploading' mt="10px" onClick={projectDifference===0?upload:warnUpload}>Submit</Button>
             }
 
         </Container>


### PR DESCRIPTION
# Changes
- Added endpoint to count how many projects are on a dataset
- endpoint to get all projects on a specific dataset already existed
- Added check on if the editor can see all projects and warning on editing if they cannot

# Migrations


# Screenshots
<img width="795" alt="image" src="https://user-images.githubusercontent.com/38753056/166713962-b3ab1e4a-0edf-4592-b5fd-704db6de2c18.png">


# Notes 
- Need to check if the existing endpoint that gets all projects in a specific dataset or if it only gets what the user is permitted to see

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
