### PR TITLE
changed endpoint to only show projects that you are a member of

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -247,7 +247,9 @@ class ProjectListView(ListAPIView):
 
     def get_queryset(self):
         if dataset := self.request.GET.get("dataset"):
-            return Project.objects.filter(datasets__exact=dataset).distinct()
+            return Project.objects.filter(
+                datasets__exact=dataset, members__id=self.request.user.id
+            ).distinct()
 
         return Project.objects.all()
 


### PR DESCRIPTION
# Changes

- changed endpoint to only show projects that you are a member of. 

# Notes
- Upload scanreport currently uses this endpoint to get all the projects in a dataset so that it can get all the members in all projects in a dataset which it uses to populate the select elements for viewers etc. This change may break that functionality as the user would only see members of projects that they can see

# Migrations

# Screenshots

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
