### PR TITLE
Bugfix/dataset only sets one admin

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -464,7 +464,10 @@ class DatasetCreateView(generics.CreateAPIView):
     queryset = Dataset.objects.all()
 
     def perform_create(self, serializer):
-        serializer.save(admins=[self.request.user])
+        if not serializer.initial_data.get("admins"):
+            serializer.save(admins=[self.request.user])
+        else:
+            serializer.save()
 
 
 class DatasetRetrieveView(generics.RetrieveAPIView):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -463,6 +463,9 @@ class DatasetCreateView(generics.CreateAPIView):
     serializer_class = DatasetViewSerializer
     queryset = Dataset.objects.all()
 
+    def perform_create(self, serializer):
+        serializer.save(admins=[self.request.user])
+
 
 class DatasetRetrieveView(generics.RetrieveAPIView):
     """

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -464,8 +464,14 @@ class DatasetCreateView(generics.CreateAPIView):
     queryset = Dataset.objects.all()
 
     def perform_create(self, serializer):
-        if not serializer.initial_data.get("admins"):
+        admins = serializer.initial_data.get("admins")
+        # If no admins given, add the user uploading the dataset
+        if not admins:
             serializer.save(admins=[self.request.user])
+        # If the user is not in the admins, add them
+        elif self.request.user.id not in admins:
+            serializer.save(admins=admins + [self.request.user.id])
+        # All is well, save
         else:
             serializer.save()
 

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -463,9 +463,6 @@ class DatasetCreateView(generics.CreateAPIView):
     serializer_class = DatasetViewSerializer
     queryset = Dataset.objects.all()
 
-    def perform_create(self, serializer):
-        serializer.save(admins=[self.request.user])
-
 
 class DatasetRetrieveView(generics.RetrieveAPIView):
     """

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Please append a line to the changelog for each change made.
 * `editors` and `admins` field for dataset shown for PUBLIC dataset as well as RESTRICTED.
 
 ### Bugfixes
+* Admins specified by the user for Datasets on the SR upload form will now be added along with the user - who is already made an admin by default.
 
 ## v2.0.0 was released 04/05/22
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Please append a line to the changelog for each change made.
 
 ### Bugfixes
 * Admins specified by the user for Datasets on the SR upload form will now be added along with the user - who is already made an admin by default.
+  * Added tooltip to the form to explain this.
 
 ## v2.0.0 was released 04/05/22
 

--- a/react-client-app/src/components/UploadScanReport.jsx
+++ b/react-client-app/src/components/UploadScanReport.jsx
@@ -163,7 +163,7 @@ const UploadScanReport = ({ setTitle }) => {
                 name: newDatasetName,
                 visibility: datasetVisibleToPublic ? "PUBLIC" : "RESTRICTED",
                 editors: datasetEditors.map(item => item.id),
-                admins: datasetAdmins.map(item => item.id)//users.map(item => item.id), Not sure what this was doing. Seemingly mapping the list of viewers to admins
+                admins: datasetAdmins.map(item => item.id),
             }
             if (!datasetVisibleToPublic) {
                 data.viewers = users.map(item => item.id)

--- a/react-client-app/src/components/UploadScanReport.jsx
+++ b/react-client-app/src/components/UploadScanReport.jsx
@@ -459,6 +459,7 @@ const UploadScanReport = ({ setTitle }) => {
                                             <CCMultiSelectInput
                                                 id={"dataset-admins"}
                                                 label={"Admins"}
+                                                info={"As the creator of this Dataset, you will automatically be one of its admins."}
                                                 isLoading={activeUsersList == undefined}
                                                 selectOptions={activeUsersList ? filterProjectUsers().map(item => item.username) : []}
                                                 currentSelections={datasetAdmins.map(item => item.username)}


### PR DESCRIPTION
# Changes

- Admins specified by the user for Datasets on the SR upload form will now be added along with the user - who is already made an admin by default.
  - Added tooltip to the form to explain this.
# Migrations
# Screenshots
# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [X] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
