### PR TITLE
Fix link which breaks logic on repeated button presses

### DIFF
--- a/react-client-app/src/views/DatasetsContent.jsx
+++ b/react-client-app/src/views/DatasetsContent.jsx
@@ -139,7 +139,7 @@ const DatasetsContent = (props) => {
         if (active.current === true) {
             active.current = false
             setDisplayedData(archivedReports.current)
-            window.history.pushState({}, '', `/datasets/${datasetId}?filter=archived`)
+            window.history.pushState({}, '', `/datasets/${datasetId}/?filter=archived`)
             setTitle(`Scanreports in Dataset #${datasetId}`);
         }
 


### PR DESCRIPTION
# Changes

Add slash into URL to not break the later logic in the Dataset contents page.

# Migrations

# Screenshots

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
