### PR TITLE
Remove specimen support in manual mapping and Azure functions

### DIFF
--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -21,7 +21,6 @@ m_allowed_tables = [
     "observation",
     "drug_exposure",
     "procedure_occurrence",
-    "specimen",
     "device_exposure",
 ]
 
@@ -33,7 +32,6 @@ m_date_field_mapper = {
     "observation": ["observation_datetime"],
     "drug_exposure": ["drug_exposure_start_datetime", "drug_exposure_end_datetime"],
     "procedure_occurrence": ["procedure_datetime"],
-    "specimen": ["specimen_datetime"],
     "device_exposure": [
         "device_exposure_start_datetime",
         "device_exposure_end_datetime",

--- a/app/workers/RulesConceptsActivity/__init__.py
+++ b/app/workers/RulesConceptsActivity/__init__.py
@@ -30,7 +30,6 @@ ALLOWED_DOMAINS = [
     "observation",
     "drug",
     "procedure",
-    "specimen",
     "device",
 ]
 


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🛠️ Repo maintenance

## PR Description
This PR removed the support for `specimen` OMOP table in the Workers app (Azure functions) and backend (for manual mapping). Reasons:
- The mapping rules creation for concepts having the domains `Specimen` (e.g., Q55.6) or `Spec Anatomic Site` (e.g., Z50.2) (which will ended up in the table `specimen`) will fail for manual mapping and auto-mapping (using Azure function). This failure is because of the lack of the field `specimen_source_concept_id` or  `anatomic_site_source_concept_id` in OMOP CDM which is not supported yet in the logic of `save_mapping_rules` function in the `shared` app. 

## Related Issues or other material
Related #406


