### PR TITLE
Make `code` section in dictionary  case insensitive

### DIFF
--- a/app/airflow/dags/libs/auto_mapping/find_standard_V_concepts.py
+++ b/app/airflow/dags/libs/auto_mapping/find_standard_V_concepts.py
@@ -96,7 +96,7 @@ def find_standard_concepts(**kwargs) -> None:
         # Process each field-vocabulary pair
         for pair in field_vocab_pairs:
             sr_field_id = pair["sr_field_id"]
-            vocabulary_id = pair["vocabulary_id"]
+            vocabulary_id = pair["vocabulary_id"].upper()
 
             if not sr_field_id or not vocabulary_id:
                 raise AirflowException(
@@ -120,7 +120,7 @@ def find_standard_concepts(**kwargs) -> None:
             FROM mapping_scanreportvalue AS sr_value
             JOIN omop.concept AS src_concept ON
                 src_concept.concept_code = sr_value.value AND
-                src_concept.vocabulary_id = %(vocabulary_id)s
+                UPPER(src_concept.vocabulary_id) = %(vocabulary_id)s
             JOIN omop.concept_relationship AS concept_relationship ON
                 concept_relationship.concept_id_1 = src_concept.concept_id AND
                 concept_relationship.relationship_id = 'Maps to'

--- a/app/workers/RulesConceptsActivity/__init__.py
+++ b/app/workers/RulesConceptsActivity/__init__.py
@@ -227,7 +227,7 @@ def _get_concepts_for_vocab(
     concept_codes = [entry["value"] for entry in entries]
 
     concepts = Concept.objects.filter(
-        concept_code__in=concept_codes, vocabulary_id=vocab
+        concept_code__in=concept_codes, vocabulary_id__iexact=vocab
     ).values_list("concept_code", "concept_id", "standard_concept")
 
     return list(concepts)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 name: carrot-mapper-dev
 
-x-airflow-common:
-  &airflow-common
+x-airflow-common: &airflow-common
   profiles: ["main"]
   volumes:
     - ./app/airflow/dags:/opt/airflow/dags
@@ -12,8 +11,7 @@ x-airflow-common:
       condition: service_started
     api:
       condition: service_healthy
-  environment:
-    &airflow-common-env
+  environment: &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     # Database connection here needs to be in URI format. With real values, which have special characters, they need to be encoded using the ref. in https://www.w3schools.com/tags/ref_urlencode.ASP.
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://postgres:postgres@db:5432/postgres?options=-csearch_path%3Dairflow
@@ -84,8 +82,6 @@ services:
       - /app/.next
     depends_on:
       api:
-        condition: service_healthy
-      airflow-webserver:
         condition: service_healthy
 
   api:
@@ -233,18 +229,13 @@ services:
         AIRFLOW_COMPONENT: webserver
     ports:
       - "8080:8080"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
     environment:
       <<: *airflow-common-env
       # Admin user configuration to access the Airlfow API
       # TODO: add optional admin user configuration in the docs
       AIRFLOW_ADMIN_USERNAME: admin
       AIRFLOW_ADMIN_PASSWORD: admin
-      
+
   scheduler:
     <<: *airflow-common
     build:


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature


## PR Description
This PR made the process of finding V concept case-insensitive, regarding the `code` in the DD.
It also removed the dependency between the frontend and airflow in Docker Compose stack, which can cause conflicts when changing the worker service type.

## Related Issues or other material
Closes #687 


