### PR TITLE
Reusing the R concepts

### DIFF
--- a/app/airflow/dags/libs/queries.py
+++ b/app/airflow/dags/libs/queries.py
@@ -309,7 +309,7 @@ WITH
         JOIN mapping_scanreportvalue AS sr_value ON sr_value.scan_report_field_id = sr_field.id
         JOIN mapping_scanreportconcept AS sr_concept ON sr_concept.object_id = sr_value.id
             AND sr_concept.content_type_id = (SELECT id FROM value_content_type)
-            AND sr_concept.creation_type = 'M'
+            AND (sr_concept.creation_type = 'M' OR sr_concept.creation_type = 'R')
         CROSS JOIN value_content_type
     )
 INSERT INTO temp_reuse_concepts_%(table_id)s (
@@ -358,7 +358,7 @@ WITH
         JOIN mapping_scanreportfield AS sr_field ON sr_field.scan_report_table_id = sr_table.id
         JOIN mapping_scanreportconcept AS sr_concept ON sr_concept.object_id = sr_field.id
             AND sr_concept.content_type_id = (SELECT id FROM field_content_type)
-            AND sr_concept.creation_type = 'M'
+            AND (sr_concept.creation_type = 'M' OR sr_concept.creation_type = 'R')
         CROSS JOIN field_content_type
     )
 INSERT INTO temp_reuse_concepts_%(table_id)s (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,7 +253,7 @@ services:
       AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER: True
       AIRFLOW_DEBUG_MODE: False
       # Search recommendations feature flag - controls whether search recommendations task is included in auto_mapping DAG
-      SEARCH_ENABLED: "true"
+      SEARCH_ENABLED: False
       AIRFLOW_DAGRUN_TIMEOUT: 60 # Timeout for each dagrun in minutes
 
 volumes:


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description
This PR enable the reuse function in Mapper to reuse the R concepts as well as the M concepts.

This is a hot fix.

