### PR TITLE
Wrap text for tooltips content

### DIFF
--- a/app/next-client-app/components/core/StatusIcon.tsx
+++ b/app/next-client-app/components/core/StatusIcon.tsx
@@ -63,7 +63,7 @@ export function StatusIcon({
     <TooltipProvider delayDuration={100}>
       <Tooltip>
         <TooltipTrigger asChild>{iconElement}</TooltipTrigger>
-        <TooltipContent className="max-w-[500px] text-center">
+        <TooltipContent className="max-w-[500px] text-center whitespace-pre-wrap">
           <p>
             {status.value === "FAILED" && statusDetails !== ""
               ? statusDetails


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
A tiny bug fix for the tooltip contents, which can't be seen fully when there is an error status.
 
Before:
<img width="560" height="197" alt="Screenshot 2025-08-04 at 11 13 26" src="https://github.com/user-attachments/assets/58f105e5-b021-4acd-bfca-7148bec7b6c6" />


After:

<img width="560" height="197" alt="Screenshot 2025-08-04 at 11 17 36" src="https://github.com/user-attachments/assets/2bc3ad09-37c0-4c7a-a803-ae3540847124" />

