### PR TITLE
Complete BigAutoField Migrations

### DIFF
--- a/app/api/files/migrations/0002_alter_filedownload_id_alter_filetype_id.py
+++ b/app/api/files/migrations/0002_alter_filedownload_id_alter_filetype_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("files", "0001_initial"),
     ]

--- a/app/api/jobs/migrations/0004_alter_job_id_alter_jobstage_id_alter_stagestatus_id.py
+++ b/app/api/jobs/migrations/0004_alter_job_id_alter_jobstage_id_alter_stagestatus_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("jobs", "0003_alter_job_details"),
     ]

--- a/app/api/mapping/migrations/0013_alter_datadictionary_id_alter_datapartner_id_and_more.py
+++ b/app/api/mapping/migrations/0013_alter_datadictionary_id_alter_datapartner_id_and_more.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("mapping", "0012_mappingrecommendation"),
     ]


### PR DESCRIPTION

🛠️ Repo maintenance

## PR Description
This PR makes and applies new migrations for BigAutoField for 'files', 'jobs', 'mapping'  models.

Migrations were applied sucessfully and a test was done to ensure no features were broken

## Related Issues or other material
Related #1260 
Closes #1260 

## Screenshots, example outputs/behaviour etc.
```
> uv run python manage.py migrate                           
warning: The `requires-python` specifier (`~=3.11`) in `api` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.11, <4`. Did you mean `~=3.11.0` to constrain the version as `>=3.11.0, <3.12`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
/Users/brian/Documents/carrot-mapper/app/api/.venv/lib/python3.14/site-packages/dj_rest_auth/registration/serializers.py:228: UserWarning: app_settings.USERNAME_REQUIRED is deprecated, use: app_settings.SIGNUP_FIELDS['username']['required']
  required=allauth_account_settings.USERNAME_REQUIRED,
/Users/brian/Documents/carrot-mapper/app/api/.venv/lib/python3.14/site-packages/dj_rest_auth/registration/serializers.py:230: UserWarning: app_settings.EMAIL_REQUIRED is deprecated, use: app_settings.SIGNUP_FIELDS['email']['required']
  email = serializers.EmailField(required=allauth_account_settings.EMAIL_REQUIRED)
/Users/brian/Documents/carrot-mapper/app/api/.venv/lib/python3.14/site-packages/dj_rest_auth/registration/serializers.py:288: UserWarning: app_settings.EMAIL_REQUIRED is deprecated, use: app_settings.SIGNUP_FIELDS['email']['required']
  email = serializers.EmailField(required=allauth_account_settings.EMAIL_REQUIRED)
Operations to perform:
  Apply all migrations: account, admin, auth, authtoken, contenttypes, files, jobs, mapping, sessions, sites, socialaccount
Running migrations:
  Applying files.0002_alter_filedownload_id_alter_filetype_id... OK
  Applying jobs.0004_alter_job_id_alter_jobstage_id_alter_stagestatus_id... OK
  Applying mapping.0013_alter_datadictionary_id_alter_datapartner_id_and_more... OK
  
  ```
