### PR TITLE
Prevent Scan Report Upload button from submitting multiple times 

### DIFF
--- a/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
+++ b/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
@@ -137,12 +137,14 @@ export function CreateScanReportForm({
         validationSchema={validationSchema}
         validateOnChange={false}
         validateOnBlur={false}
-        onSubmit={(data) => {
+        onSubmit={async (data) => {
+        // Return a Promise so Formik sets isSubmitting and prevents submitting multiple times
           toast.info("Validating and uploading...");
-          handleSubmit(data);
+          await handleSubmit(data);
         }}
       >
-        {({ values, handleChange, handleSubmit, setFieldValue }) => (
+        {({ values, handleChange, handleSubmit, setFieldValue, isSubmitting }) => (
+        // added isSubmitting to the form to disable the submit button while upload is in progress
           <form
             className="w-full max-w-2xl"
             onSubmit={handleSubmit}
@@ -365,6 +367,7 @@ export function CreateScanReportForm({
                 <Button
                   type="submit"
                   disabled={
+                    isSubmitting ||
                     values.dataPartner === 0 ||
                     values.dataset === 0 ||
                     values.dataset === -1 ||


### PR DESCRIPTION
🦋 Bug Fix
## PR Description
This PR fixes the Scan Report Upload button from submitting multiple times. At the moment, users can click the button multiple times, hence creating multiple upload instances of the same files. This is not a good user experience, and it also uses a lot of resources trying to upload multiple instances.

The fix disables the button upon the first click, thus preventing multiple clicks.

## Related Issues or other material
Related #1261 
Closes #1261 

## Screenshots, example outputs/behaviour etc.
<img width="1680" height="1050" alt="Disabled" src="https://github.com/user-attachments/assets/a5d8f5a2-ebba-4c19-810f-f4c63d450b28" />
